### PR TITLE
feat: implement core CRUD endpoints for user collection

### DIFF
--- a/src/__tests__/collectionApi.test.ts
+++ b/src/__tests__/collectionApi.test.ts
@@ -1,0 +1,576 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { handler as collectionHandler } from '../pages/api/collection';
+import { handler as collectionEntryHandler } from '../pages/api/collection/[entryId]';
+import { supabase } from '../lib/supabaseClient';
+
+// Mock the supabase client
+vi.mock('../lib/supabaseClient', () => ({
+  supabase: {
+    auth: {
+      getUser: vi.fn()
+    },
+    from: vi.fn(() => ({
+      select: vi.fn(() => ({
+        eq: vi.fn(() => ({
+          single: vi.fn(),
+          order: vi.fn(() => ({}))
+        })),
+        neq: vi.fn(() => ({
+          single: vi.fn()
+        }))
+      })),
+      insert: vi.fn(() => ({
+        select: vi.fn(() => ({
+          single: vi.fn()
+        }))
+      })),
+      update: vi.fn(() => ({
+        eq: vi.fn(() => ({
+          select: vi.fn(() => ({
+            single: vi.fn()
+          }))
+        }))
+      })),
+      delete: vi.fn(() => ({
+        eq: vi.fn()
+      }))
+    }))
+  }
+}));
+
+describe('Collection API Integration Tests', () => {
+  const mockUser = {
+    id: 'test-user-id-123',
+    email: 'test@example.com'
+  };
+
+  const mockCollectionItem = {
+    id: 'collection-item-123',
+    user_id: 'test-user-id-123',
+    series_id: 'series-123',
+    issue_id: 'issue-123',
+    grade_id: 'grade-123',
+    acquisition_date: '2024-01-01',
+    acquisition_price: 50.00,
+    current_value: 75.00,
+    notes: 'Great condition',
+    condition_notes: 'Minor spine wear',
+    storage_location: 'Box 1',
+    personal_rating: 8,
+    created_at: '2024-01-01T00:00:00Z',
+    updated_at: '2024-01-01T00:00:00Z',
+    comic_series: { name: 'Amazing Spider-Man', publisher: 'Marvel' },
+    comic_issues: { issue_number: '1', variant: null, key_issue: true },
+    grading_standards: { company: 'CGC', grade_label: 'VF+', grade_value: 8.5 }
+  };
+
+  const validAuthHeader = 'Bearer valid-jwt-token';
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('GET /api/collection', () => {
+    it('should retrieve user collection successfully', async () => {
+      // Mock successful authentication
+      (supabase.auth.getUser as any).mockResolvedValue({
+        data: { user: mockUser },
+        error: null
+      });
+
+      // Mock database query
+      const mockQuery = {
+        eq: vi.fn(() => mockQuery),
+        order: vi.fn(() => Promise.resolve({
+          data: [mockCollectionItem],
+          error: null
+        }))
+      };
+      
+      const mockSelect = vi.fn(() => mockQuery);
+      (supabase.from as any).mockReturnValue({ select: mockSelect });
+
+      const request = new Request('http://localhost:3000/api/collection', {
+        method: 'GET',
+        headers: { 'Authorization': validAuthHeader }
+      });
+
+      const response = await collectionHandler(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.success).toBe(true);
+      expect(data.data).toHaveLength(1);
+      expect(data.data[0]).toEqual(mockCollectionItem);
+      expect(data.message).toBe('Retrieved 1 collection items');
+    });
+
+    it('should return 401 for missing authorization header', async () => {
+      const request = new Request('http://localhost:3000/api/collection', {
+        method: 'GET'
+      });
+
+      const response = await collectionHandler(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(401);
+      expect(data.success).toBe(false);
+      expect(data.error).toBe('Authorization header required');
+    });
+
+    it('should return 401 for invalid token', async () => {
+      (supabase.auth.getUser as any).mockResolvedValue({
+        data: { user: null },
+        error: { message: 'Invalid token' }
+      });
+
+      const request = new Request('http://localhost:3000/api/collection', {
+        method: 'GET',
+        headers: { 'Authorization': 'Bearer invalid-token' }
+      });
+
+      const response = await collectionHandler(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(401);
+      expect(data.success).toBe(false);
+      expect(data.error).toBe('Invalid or expired token');
+    });
+
+    it('should handle database errors gracefully', async () => {
+      (supabase.auth.getUser as any).mockResolvedValue({
+        data: { user: mockUser },
+        error: null
+      });
+
+      const mockQuery = {
+        eq: vi.fn(() => mockQuery),
+        order: vi.fn(() => Promise.resolve({
+          data: null,
+          error: { message: 'Database connection failed' }
+        }))
+      };
+      
+      (supabase.from as any).mockReturnValue({ select: vi.fn(() => mockQuery) });
+
+      const request = new Request('http://localhost:3000/api/collection', {
+        method: 'GET',
+        headers: { 'Authorization': validAuthHeader }
+      });
+
+      const response = await collectionHandler(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(500);
+      expect(data.success).toBe(false);
+      expect(data.error).toBe('Failed to retrieve collection');
+    });
+  });
+
+  describe('POST /api/collection', () => {
+    const validCollectionData = {
+      series_id: 'series-123',
+      issue_id: 'issue-123',
+      grade_id: 'grade-123',
+      acquisition_date: '2024-01-01',
+      acquisition_price: 50.00,
+      personal_rating: 8
+    };
+
+    it('should add comic to collection successfully', async () => {
+      // Mock successful authentication
+      (supabase.auth.getUser as any).mockResolvedValue({
+        data: { user: mockUser },
+        error: null
+      });
+
+      // Mock existing item check (no duplicate)
+      const mockSelectQuery = {
+        eq: vi.fn(() => mockSelectQuery),
+        single: vi.fn(() => Promise.resolve({
+          data: null,
+          error: { code: 'PGRST116' } // No rows found
+        }))
+      };
+      
+      // Mock insert operation
+      const mockInsertQuery = {
+        select: vi.fn(() => ({
+          single: vi.fn(() => Promise.resolve({
+            data: mockCollectionItem,
+            error: null
+          }))
+        }))
+      };
+
+      (supabase.from as any)
+        .mockReturnValueOnce({ select: vi.fn(() => mockSelectQuery) }) // For duplicate check
+        .mockReturnValueOnce({ insert: vi.fn(() => mockInsertQuery) }); // For insert
+
+      const request = new Request('http://localhost:3000/api/collection', {
+        method: 'POST',
+        headers: { 
+          'Authorization': validAuthHeader,
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify(validCollectionData)
+      });
+
+      const response = await collectionHandler(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(201);
+      expect(data.success).toBe(true);
+      expect(data.data).toEqual(mockCollectionItem);
+      expect(data.message).toBe('Comic added to collection successfully');
+    });
+
+    it('should return 400 for missing required fields', async () => {
+      (supabase.auth.getUser as any).mockResolvedValue({
+        data: { user: mockUser },
+        error: null
+      });
+
+      const invalidData = { grade_id: 'grade-123' }; // Missing series_id and issue_id
+
+      const request = new Request('http://localhost:3000/api/collection', {
+        method: 'POST',
+        headers: { 
+          'Authorization': validAuthHeader,
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify(invalidData)
+      });
+
+      const response = await collectionHandler(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(data.success).toBe(false);
+      expect(data.error).toBe('series_id and issue_id are required');
+    });
+
+    it('should return 400 for invalid personal_rating', async () => {
+      (supabase.auth.getUser as any).mockResolvedValue({
+        data: { user: mockUser },
+        error: null
+      });
+
+      const invalidData = {
+        ...validCollectionData,
+        personal_rating: 11 // Out of valid range (1-10)
+      };
+
+      const request = new Request('http://localhost:3000/api/collection', {
+        method: 'POST',
+        headers: { 
+          'Authorization': validAuthHeader,
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify(invalidData)
+      });
+
+      const response = await collectionHandler(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(data.success).toBe(false);
+      expect(data.error).toBe('personal_rating must be between 1 and 10');
+    });
+
+    it('should return 409 for duplicate collection item', async () => {
+      (supabase.auth.getUser as any).mockResolvedValue({
+        data: { user: mockUser },
+        error: null
+      });
+
+      // Mock existing item check (duplicate found)
+      const mockSelectQuery = {
+        eq: vi.fn(() => mockSelectQuery),
+        single: vi.fn(() => Promise.resolve({
+          data: { id: 'existing-item-123' },
+          error: null
+        }))
+      };
+      
+      (supabase.from as any).mockReturnValue({ select: vi.fn(() => mockSelectQuery) });
+
+      const request = new Request('http://localhost:3000/api/collection', {
+        method: 'POST',
+        headers: { 
+          'Authorization': validAuthHeader,
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify(validCollectionData)
+      });
+
+      const response = await collectionHandler(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(409);
+      expect(data.success).toBe(false);
+      expect(data.error).toBe('This comic is already in your collection');
+    });
+  });
+
+  describe('PUT /api/collection/[entryId]', () => {
+    const entryId = 'collection-item-123';
+    const updateData = {
+      acquisition_price: 60.00,
+      current_value: 80.00,
+      notes: 'Updated notes',
+      personal_rating: 9
+    };
+
+    it('should update collection entry successfully', async () => {
+      // Mock successful authentication
+      (supabase.auth.getUser as any).mockResolvedValue({
+        data: { user: mockUser },
+        error: null
+      });
+
+      // Mock existing item check
+      const mockExistingQuery = {
+        eq: vi.fn(() => mockExistingQuery),
+        single: vi.fn(() => Promise.resolve({
+          data: { id: entryId, user_id: mockUser.id },
+          error: null
+        }))
+      };
+
+      // Mock update operation
+      const mockUpdateQuery = {
+        eq: vi.fn(() => mockUpdateQuery),
+        select: vi.fn(() => ({
+          single: vi.fn(() => Promise.resolve({
+            data: { ...mockCollectionItem, ...updateData },
+            error: null
+          }))
+        }))
+      };
+
+      (supabase.from as any)
+        .mockReturnValueOnce({ select: vi.fn(() => mockExistingQuery) }) // For existence check
+        .mockReturnValueOnce({ update: vi.fn(() => mockUpdateQuery) }); // For update
+
+      const request = new Request(`http://localhost:3000/api/collection/${entryId}`, {
+        method: 'PUT',
+        headers: { 
+          'Authorization': validAuthHeader,
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify(updateData)
+      });
+
+      const response = await collectionEntryHandler(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.success).toBe(true);
+      expect(data.message).toBe('Collection entry updated successfully');
+      expect(data.data.acquisition_price).toBe(updateData.acquisition_price);
+    });
+
+    it('should return 404 for non-existent entry', async () => {
+      (supabase.auth.getUser as any).mockResolvedValue({
+        data: { user: mockUser },
+        error: null
+      });
+
+      const mockExistingQuery = {
+        eq: vi.fn(() => mockExistingQuery),
+        single: vi.fn(() => Promise.resolve({
+          data: null,
+          error: { code: 'PGRST116' }
+        }))
+      };
+
+      (supabase.from as any).mockReturnValue({ select: vi.fn(() => mockExistingQuery) });
+
+      const request = new Request(`http://localhost:3000/api/collection/${entryId}`, {
+        method: 'PUT',
+        headers: { 
+          'Authorization': validAuthHeader,
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify(updateData)
+      });
+
+      const response = await collectionEntryHandler(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(404);
+      expect(data.success).toBe(false);
+      expect(data.error).toBe('Collection entry not found or unauthorized');
+    });
+
+    it('should return 400 for invalid entry ID format', async () => {
+      const invalidEntryId = 'invalid-id';
+      
+      const request = new Request(`http://localhost:3000/api/collection/${invalidEntryId}`, {
+        method: 'PUT',
+        headers: { 
+          'Authorization': validAuthHeader,
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify(updateData)
+      });
+
+      const response = await collectionEntryHandler(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(data.success).toBe(false);
+      expect(data.error).toBe('Invalid entry ID format');
+    });
+
+    it('should return 400 for no fields to update', async () => {
+      (supabase.auth.getUser as any).mockResolvedValue({
+        data: { user: mockUser },
+        error: null
+      });
+
+      const mockExistingQuery = {
+        eq: vi.fn(() => mockExistingQuery),
+        single: vi.fn(() => Promise.resolve({
+          data: { id: entryId, user_id: mockUser.id },
+          error: null
+        }))
+      };
+
+      (supabase.from as any).mockReturnValue({ select: vi.fn(() => mockExistingQuery) });
+
+      const request = new Request(`http://localhost:3000/api/collection/${entryId}`, {
+        method: 'PUT',
+        headers: { 
+          'Authorization': validAuthHeader,
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({}) // Empty update data
+      });
+
+      const response = await collectionEntryHandler(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(data.success).toBe(false);
+      expect(data.error).toBe('No fields provided for update');
+    });
+  });
+
+  describe('DELETE /api/collection/[entryId]', () => {
+    const entryId = 'collection-item-123';
+
+    it('should delete collection entry successfully', async () => {
+      // Mock successful authentication
+      (supabase.auth.getUser as any).mockResolvedValue({
+        data: { user: mockUser },
+        error: null
+      });
+
+      // Mock existing item check
+      const mockExistingQuery = {
+        eq: vi.fn(() => mockExistingQuery),
+        single: vi.fn(() => Promise.resolve({
+          data: mockCollectionItem,
+          error: null
+        }))
+      };
+
+      // Mock delete operation
+      const mockDeleteQuery = {
+        eq: vi.fn(() => Promise.resolve({
+          error: null
+        }))
+      };
+
+      (supabase.from as any)
+        .mockReturnValueOnce({ select: vi.fn(() => mockExistingQuery) }) // For existence check
+        .mockReturnValueOnce({ delete: vi.fn(() => mockDeleteQuery) }); // For delete
+
+      const request = new Request(`http://localhost:3000/api/collection/${entryId}`, {
+        method: 'DELETE',
+        headers: { 'Authorization': validAuthHeader }
+      });
+
+      const response = await collectionEntryHandler(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.success).toBe(true);
+      expect(data.message).toBe('Collection entry deleted successfully');
+      expect(data.data).toEqual(mockCollectionItem);
+    });
+
+    it('should return 404 for non-existent entry', async () => {
+      (supabase.auth.getUser as any).mockResolvedValue({
+        data: { user: mockUser },
+        error: null
+      });
+
+      const mockExistingQuery = {
+        eq: vi.fn(() => mockExistingQuery),
+        single: vi.fn(() => Promise.resolve({
+          data: null,
+          error: { code: 'PGRST116' }
+        }))
+      };
+
+      (supabase.from as any).mockReturnValue({ select: vi.fn(() => mockExistingQuery) });
+
+      const request = new Request(`http://localhost:3000/api/collection/${entryId}`, {
+        method: 'DELETE',
+        headers: { 'Authorization': validAuthHeader }
+      });
+
+      const response = await collectionEntryHandler(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(404);
+      expect(data.success).toBe(false);
+      expect(data.error).toBe('Collection entry not found or unauthorized');
+    });
+  });
+
+  describe('CORS and Method Validation', () => {
+    it('should handle OPTIONS requests (CORS preflight)', async () => {
+      const request = new Request('http://localhost:3000/api/collection', {
+        method: 'OPTIONS'
+      });
+
+      const response = await collectionHandler(request);
+
+      expect(response.status).toBe(200);
+      expect(response.headers.get('Access-Control-Allow-Origin')).toBe('*');
+      expect(response.headers.get('Access-Control-Allow-Methods')).toContain('GET');
+      expect(response.headers.get('Access-Control-Allow-Methods')).toContain('POST');
+    });
+
+    it('should return 405 for unsupported methods on collection endpoint', async () => {
+      const request = new Request('http://localhost:3000/api/collection', {
+        method: 'PATCH'
+      });
+
+      const response = await collectionHandler(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(405);
+      expect(data.success).toBe(false);
+      expect(data.error).toBe('Method not allowed');
+    });
+
+    it('should return 405 for unsupported methods on collection entry endpoint', async () => {
+      const entryId = 'collection-item-123';
+      const request = new Request(`http://localhost:3000/api/collection/${entryId}`, {
+        method: 'POST'
+      });
+
+      const response = await collectionEntryHandler(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(405);
+      expect(data.success).toBe(false);
+      expect(data.error).toBe('Method not allowed');
+    });
+  });
+});

--- a/src/pages/api/collection.ts
+++ b/src/pages/api/collection.ts
@@ -1,0 +1,265 @@
+import { supabase } from '../../lib/supabaseClient';
+
+interface CollectionItem {
+  id: string;
+  user_id: string;
+  series_id: string;
+  issue_id: string;
+  grade_id?: string;
+  acquisition_date?: string;
+  acquisition_price?: number;
+  current_value?: number;
+  notes?: string;
+  condition_notes?: string;
+  storage_location?: string;
+  personal_rating?: number;
+  created_at: string;
+  updated_at: string;
+}
+
+interface AddCollectionRequest {
+  series_id: string;
+  issue_id: string;
+  grade_id?: string;
+  acquisition_date?: string;
+  acquisition_price?: number;
+  current_value?: number;
+  notes?: string;
+  condition_notes?: string;
+  storage_location?: string;
+  personal_rating?: number;
+}
+
+interface UpdateCollectionRequest extends Partial<AddCollectionRequest> {}
+
+interface ApiResponse<T = any> {
+  success: boolean;
+  data?: T;
+  error?: string;
+  message?: string;
+}
+
+/**
+ * Extract and validate JWT token from Authorization header
+ */
+async function validateAuthToken(request: Request): Promise<{ user: any; error?: string }> {
+  const authHeader = request.headers.get('Authorization');
+  
+  if (!authHeader || !authHeader.startsWith('Bearer ')) {
+    return { user: null, error: 'Authorization header required' };
+  }
+
+  const token = authHeader.substring(7);
+  
+  try {
+    const { data: { user }, error } = await supabase.auth.getUser(token);
+    
+    if (error || !user) {
+      return { user: null, error: 'Invalid or expired token' };
+    }
+    
+    return { user };
+  } catch (error) {
+    return { user: null, error: 'Token validation failed' };
+  }
+}
+
+/**
+ * GET /api/collection - Retrieve user's collection
+ */
+async function handleGetCollection(request: Request): Promise<Response> {
+  const { user, error: authError } = await validateAuthToken(request);
+  
+  if (authError || !user) {
+    return new Response(
+      JSON.stringify({ success: false, error: authError || 'Unauthorized' }),
+      { status: 401, headers: { 'Content-Type': 'application/json' } }
+    );
+  }
+
+  try {
+    const { data, error } = await supabase
+      .from('user_collections')
+      .select(`
+        *,
+        comic_series:series_id(name, publisher),
+        comic_issues:issue_id(issue_number, variant, key_issue),
+        grading_standards:grade_id(company, grade_label, grade_value)
+      `)
+      .eq('user_id', user.id)
+      .order('created_at', { ascending: false });
+
+    if (error) {
+      console.error('Database error:', error);
+      return new Response(
+        JSON.stringify({ success: false, error: 'Failed to retrieve collection' }),
+        { status: 500, headers: { 'Content-Type': 'application/json' } }
+      );
+    }
+
+    return new Response(
+      JSON.stringify({
+        success: true,
+        data: data || [],
+        message: `Retrieved ${data?.length || 0} collection items`
+      }),
+      { status: 200, headers: { 'Content-Type': 'application/json' } }
+    );
+
+  } catch (error) {
+    console.error('API Error in GET /api/collection:', error);
+    return new Response(
+      JSON.stringify({ success: false, error: 'Internal server error' }),
+      { status: 500, headers: { 'Content-Type': 'application/json' } }
+    );
+  }
+}
+
+/**
+ * POST /api/collection - Add comic to user's collection
+ */
+async function handleAddToCollection(request: Request): Promise<Response> {
+  const { user, error: authError } = await validateAuthToken(request);
+  
+  if (authError || !user) {
+    return new Response(
+      JSON.stringify({ success: false, error: authError || 'Unauthorized' }),
+      { status: 401, headers: { 'Content-Type': 'application/json' } }
+    );
+  }
+
+  try {
+    const body: AddCollectionRequest = await request.json();
+    
+    // Validate required fields
+    if (!body.series_id || !body.issue_id) {
+      return new Response(
+        JSON.stringify({ 
+          success: false, 
+          error: 'series_id and issue_id are required' 
+        }),
+        { status: 400, headers: { 'Content-Type': 'application/json' } }
+      );
+    }
+
+    // Validate personal_rating if provided
+    if (body.personal_rating !== undefined && (body.personal_rating < 1 || body.personal_rating > 10)) {
+      return new Response(
+        JSON.stringify({ 
+          success: false, 
+          error: 'personal_rating must be between 1 and 10' 
+        }),
+        { status: 400, headers: { 'Content-Type': 'application/json' } }
+      );
+    }
+
+    // Check if item already exists in collection
+    const { data: existing } = await supabase
+      .from('user_collections')
+      .select('id')
+      .eq('user_id', user.id)
+      .eq('series_id', body.series_id)
+      .eq('issue_id', body.issue_id)
+      .eq('grade_id', body.grade_id || null)
+      .single();
+
+    if (existing) {
+      return new Response(
+        JSON.stringify({ 
+          success: false, 
+          error: 'This comic is already in your collection' 
+        }),
+        { status: 409, headers: { 'Content-Type': 'application/json' } }
+      );
+    }
+
+    // Insert new collection item
+    const { data, error } = await supabase
+      .from('user_collections')
+      .insert({
+        user_id: user.id,
+        series_id: body.series_id,
+        issue_id: body.issue_id,
+        grade_id: body.grade_id || null,
+        acquisition_date: body.acquisition_date || null,
+        acquisition_price: body.acquisition_price || null,
+        current_value: body.current_value || null,
+        notes: body.notes || null,
+        condition_notes: body.condition_notes || null,
+        storage_location: body.storage_location || null,
+        personal_rating: body.personal_rating || null
+      })
+      .select(`
+        *,
+        comic_series:series_id(name, publisher),
+        comic_issues:issue_id(issue_number, variant, key_issue),
+        grading_standards:grade_id(company, grade_label, grade_value)
+      `)
+      .single();
+
+    if (error) {
+      console.error('Database error:', error);
+      return new Response(
+        JSON.stringify({ success: false, error: 'Failed to add comic to collection' }),
+        { status: 500, headers: { 'Content-Type': 'application/json' } }
+      );
+    }
+
+    return new Response(
+      JSON.stringify({
+        success: true,
+        data,
+        message: 'Comic added to collection successfully'
+      }),
+      { status: 201, headers: { 'Content-Type': 'application/json' } }
+    );
+
+  } catch (parseError) {
+    console.error('Parse error:', parseError);
+    return new Response(
+      JSON.stringify({ success: false, error: 'Invalid JSON in request body' }),
+      { status: 400, headers: { 'Content-Type': 'application/json' } }
+    );
+  }
+}
+
+/**
+ * Main API handler for /api/collection
+ */
+export async function handler(request: Request): Promise<Response> {
+  try {
+    // Handle CORS preflight requests
+    if (request.method === 'OPTIONS') {
+      return new Response(null, {
+        status: 200,
+        headers: {
+          'Access-Control-Allow-Origin': '*',
+          'Access-Control-Allow-Methods': 'GET, POST, PUT, DELETE, OPTIONS',
+          'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+        },
+      });
+    }
+
+    switch (request.method) {
+      case 'GET':
+        return handleGetCollection(request);
+      case 'POST':
+        return handleAddToCollection(request);
+      default:
+        return new Response(
+          JSON.stringify({ success: false, error: 'Method not allowed' }),
+          { status: 405, headers: { 'Content-Type': 'application/json' } }
+        );
+    }
+  } catch (error) {
+    console.error('API Error in /api/collection:', error);
+    return new Response(
+      JSON.stringify({ success: false, error: 'Internal server error' }),
+      { status: 500, headers: { 'Content-Type': 'application/json' } }
+    );
+  }
+}
+
+// Export for different runtime environments
+export default handler;
+export { handler as GET, handler as POST };

--- a/src/pages/api/collection/[entryId].ts
+++ b/src/pages/api/collection/[entryId].ts
@@ -1,0 +1,314 @@
+import { supabase } from '../../../lib/supabaseClient';
+
+interface UpdateCollectionRequest {
+  series_id?: string;
+  issue_id?: string;
+  grade_id?: string;
+  acquisition_date?: string;
+  acquisition_price?: number;
+  current_value?: number;
+  notes?: string;
+  condition_notes?: string;
+  storage_location?: string;
+  personal_rating?: number;
+}
+
+interface ApiResponse<T = any> {
+  success: boolean;
+  data?: T;
+  error?: string;
+  message?: string;
+}
+
+/**
+ * Extract and validate JWT token from Authorization header
+ */
+async function validateAuthToken(request: Request): Promise<{ user: any; error?: string }> {
+  const authHeader = request.headers.get('Authorization');
+  
+  if (!authHeader || !authHeader.startsWith('Bearer ')) {
+    return { user: null, error: 'Authorization header required' };
+  }
+
+  const token = authHeader.substring(7);
+  
+  try {
+    const { data: { user }, error } = await supabase.auth.getUser(token);
+    
+    if (error || !user) {
+      return { user: null, error: 'Invalid or expired token' };
+    }
+    
+    return { user };
+  } catch (error) {
+    return { user: null, error: 'Token validation failed' };
+  }
+}
+
+/**
+ * Extract entryId from URL path
+ */
+function extractEntryId(url: string): string | null {
+  const urlObj = new URL(url);
+  const pathParts = urlObj.pathname.split('/');
+  const entryId = pathParts[pathParts.length - 1];
+  
+  // Basic UUID validation
+  const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+  
+  return uuidRegex.test(entryId) ? entryId : null;
+}
+
+/**
+ * PUT /api/collection/{entryId} - Update collection entry
+ */
+async function handleUpdateCollection(request: Request, entryId: string): Promise<Response> {
+  const { user, error: authError } = await validateAuthToken(request);
+  
+  if (authError || !user) {
+    return new Response(
+      JSON.stringify({ success: false, error: authError || 'Unauthorized' }),
+      { status: 401, headers: { 'Content-Type': 'application/json' } }
+    );
+  }
+
+  try {
+    const body: UpdateCollectionRequest = await request.json();
+
+    // Validate personal_rating if provided
+    if (body.personal_rating !== undefined && (body.personal_rating < 1 || body.personal_rating > 10)) {
+      return new Response(
+        JSON.stringify({ 
+          success: false, 
+          error: 'personal_rating must be between 1 and 10' 
+        }),
+        { status: 400, headers: { 'Content-Type': 'application/json' } }
+      );
+    }
+
+    // Check if the collection entry exists and belongs to the user
+    const { data: existing, error: checkError } = await supabase
+      .from('user_collections')
+      .select('id, user_id')
+      .eq('id', entryId)
+      .eq('user_id', user.id)
+      .single();
+
+    if (checkError || !existing) {
+      return new Response(
+        JSON.stringify({ 
+          success: false, 
+          error: 'Collection entry not found or unauthorized' 
+        }),
+        { status: 404, headers: { 'Content-Type': 'application/json' } }
+      );
+    }
+
+    // Prepare update data (only include provided fields)
+    const updateData: any = {};
+    
+    if (body.series_id !== undefined) updateData.series_id = body.series_id;
+    if (body.issue_id !== undefined) updateData.issue_id = body.issue_id;
+    if (body.grade_id !== undefined) updateData.grade_id = body.grade_id;
+    if (body.acquisition_date !== undefined) updateData.acquisition_date = body.acquisition_date;
+    if (body.acquisition_price !== undefined) updateData.acquisition_price = body.acquisition_price;
+    if (body.current_value !== undefined) updateData.current_value = body.current_value;
+    if (body.notes !== undefined) updateData.notes = body.notes;
+    if (body.condition_notes !== undefined) updateData.condition_notes = body.condition_notes;
+    if (body.storage_location !== undefined) updateData.storage_location = body.storage_location;
+    if (body.personal_rating !== undefined) updateData.personal_rating = body.personal_rating;
+
+    // If no fields to update
+    if (Object.keys(updateData).length === 0) {
+      return new Response(
+        JSON.stringify({ 
+          success: false, 
+          error: 'No fields provided for update' 
+        }),
+        { status: 400, headers: { 'Content-Type': 'application/json' } }
+      );
+    }
+
+    // Check for duplicate if series_id, issue_id, or grade_id is being changed
+    if (updateData.series_id || updateData.issue_id || updateData.grade_id !== undefined) {
+      const { data: duplicate } = await supabase
+        .from('user_collections')
+        .select('id')
+        .eq('user_id', user.id)
+        .eq('series_id', updateData.series_id || existing.series_id)
+        .eq('issue_id', updateData.issue_id || existing.issue_id)
+        .eq('grade_id', updateData.grade_id !== undefined ? updateData.grade_id : existing.grade_id)
+        .neq('id', entryId)
+        .single();
+
+      if (duplicate) {
+        return new Response(
+          JSON.stringify({ 
+            success: false, 
+            error: 'A comic with these details already exists in your collection' 
+          }),
+          { status: 409, headers: { 'Content-Type': 'application/json' } }
+        );
+      }
+    }
+
+    // Update the collection entry
+    const { data, error } = await supabase
+      .from('user_collections')
+      .update(updateData)
+      .eq('id', entryId)
+      .eq('user_id', user.id)
+      .select(`
+        *,
+        comic_series:series_id(name, publisher),
+        comic_issues:issue_id(issue_number, variant, key_issue),
+        grading_standards:grade_id(company, grade_label, grade_value)
+      `)
+      .single();
+
+    if (error) {
+      console.error('Database error:', error);
+      return new Response(
+        JSON.stringify({ success: false, error: 'Failed to update collection entry' }),
+        { status: 500, headers: { 'Content-Type': 'application/json' } }
+      );
+    }
+
+    return new Response(
+      JSON.stringify({
+        success: true,
+        data,
+        message: 'Collection entry updated successfully'
+      }),
+      { status: 200, headers: { 'Content-Type': 'application/json' } }
+    );
+
+  } catch (parseError) {
+    console.error('Parse error:', parseError);
+    return new Response(
+      JSON.stringify({ success: false, error: 'Invalid JSON in request body' }),
+      { status: 400, headers: { 'Content-Type': 'application/json' } }
+    );
+  }
+}
+
+/**
+ * DELETE /api/collection/{entryId} - Remove collection entry
+ */
+async function handleDeleteCollection(request: Request, entryId: string): Promise<Response> {
+  const { user, error: authError } = await validateAuthToken(request);
+  
+  if (authError || !user) {
+    return new Response(
+      JSON.stringify({ success: false, error: authError || 'Unauthorized' }),
+      { status: 401, headers: { 'Content-Type': 'application/json' } }
+    );
+  }
+
+  try {
+    // Check if the collection entry exists and belongs to the user
+    const { data: existing, error: checkError } = await supabase
+      .from('user_collections')
+      .select(`
+        *,
+        comic_series:series_id(name, publisher),
+        comic_issues:issue_id(issue_number, variant, key_issue),
+        grading_standards:grade_id(company, grade_label, grade_value)
+      `)
+      .eq('id', entryId)
+      .eq('user_id', user.id)
+      .single();
+
+    if (checkError || !existing) {
+      return new Response(
+        JSON.stringify({ 
+          success: false, 
+          error: 'Collection entry not found or unauthorized' 
+        }),
+        { status: 404, headers: { 'Content-Type': 'application/json' } }
+      );
+    }
+
+    // Delete the collection entry
+    const { error } = await supabase
+      .from('user_collections')
+      .delete()
+      .eq('id', entryId)
+      .eq('user_id', user.id);
+
+    if (error) {
+      console.error('Database error:', error);
+      return new Response(
+        JSON.stringify({ success: false, error: 'Failed to delete collection entry' }),
+        { status: 500, headers: { 'Content-Type': 'application/json' } }
+      );
+    }
+
+    return new Response(
+      JSON.stringify({
+        success: true,
+        data: existing,
+        message: 'Collection entry deleted successfully'
+      }),
+      { status: 200, headers: { 'Content-Type': 'application/json' } }
+    );
+
+  } catch (error) {
+    console.error('API Error in DELETE /api/collection/[entryId]:', error);
+    return new Response(
+      JSON.stringify({ success: false, error: 'Internal server error' }),
+      { status: 500, headers: { 'Content-Type': 'application/json' } }
+    );
+  }
+}
+
+/**
+ * Main API handler for /api/collection/[entryId]
+ */
+export async function handler(request: Request): Promise<Response> {
+  try {
+    // Handle CORS preflight requests
+    if (request.method === 'OPTIONS') {
+      return new Response(null, {
+        status: 200,
+        headers: {
+          'Access-Control-Allow-Origin': '*',
+          'Access-Control-Allow-Methods': 'GET, POST, PUT, DELETE, OPTIONS',
+          'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+        },
+      });
+    }
+
+    // Extract entryId from URL
+    const entryId = extractEntryId(request.url);
+    
+    if (!entryId) {
+      return new Response(
+        JSON.stringify({ success: false, error: 'Invalid entry ID format' }),
+        { status: 400, headers: { 'Content-Type': 'application/json' } }
+      );
+    }
+
+    switch (request.method) {
+      case 'PUT':
+        return handleUpdateCollection(request, entryId);
+      case 'DELETE':
+        return handleDeleteCollection(request, entryId);
+      default:
+        return new Response(
+          JSON.stringify({ success: false, error: 'Method not allowed' }),
+          { status: 405, headers: { 'Content-Type': 'application/json' } }
+        );
+    }
+  } catch (error) {
+    console.error('API Error in /api/collection/[entryId]:', error);
+    return new Response(
+      JSON.stringify({ success: false, error: 'Internal server error' }),
+      { status: 500, headers: { 'Content-Type': 'application/json' } }
+    );
+  }
+}
+
+// Export for different runtime environments
+export default handler;
+export { handler as PUT, handler as DELETE };


### PR DESCRIPTION
Implements the core CRUD functionality for managing user comic collections as requested in issue #46.

### Features
- GET /api/collection - Retrieve user's collection
- POST /api/collection - Add comics to collection
- PUT /api/collection/{entryId} - Update collection entries
- DELETE /api/collection/{entryId} - Remove from collection
- JWT authentication and proper authorization
- Comprehensive input validation and error handling
- Full vitest integration test suite

Closes #46

Generated with [Claude Code](https://claude.ai/code)