### PR TITLE
feat: Add gamification and social features API endpoints

### DIFF
--- a/src/__tests__/gamificationSocialApi.test.ts
+++ b/src/__tests__/gamificationSocialApi.test.ts
@@ -1,0 +1,691 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { handler as trophiesHandler } from '../pages/api/trophies';
+import { handler as userTrophiesHandler } from '../pages/api/users/[userId]/trophies';
+import { handler as followHandler } from '../pages/api/users/[userId]/follow';
+import { supabase } from '../lib/supabaseClient';
+
+// Mock the supabase client
+vi.mock('../lib/supabaseClient', () => ({
+  supabase: {
+    auth: {
+      getUser: vi.fn()
+    },
+    from: vi.fn(() => ({
+      select: vi.fn(() => ({
+        eq: vi.fn(() => ({
+          single: vi.fn(),
+          order: vi.fn(() => ({}))
+        })),
+        order: vi.fn(() => ({}))
+      })),
+      insert: vi.fn(() => ({
+        select: vi.fn(() => ({
+          single: vi.fn()
+        }))
+      })),
+      delete: vi.fn(() => ({
+        eq: vi.fn()
+      }))
+    }))
+  }
+}));
+
+describe('Gamification & Social API Integration Tests', () => {
+  const mockUser = {
+    id: 'test-user-id-123',
+    email: 'test@example.com'
+  };
+
+  const mockTargetUser = {
+    id: 'target-user-id-456',
+    email: 'target@example.com'
+  };
+
+  const mockTrophy = {
+    id: 'trophy-123',
+    name: 'First Comic',
+    description: 'Add your first comic to your collection',
+    category: 'collection',
+    icon: 'trophy',
+    rarity: 'common',
+    points: 10,
+    requirements: { type: 'collection_count', threshold: 1 },
+    is_active: true,
+    created_at: '2024-01-01T00:00:00Z',
+    updated_at: '2024-01-01T00:00:00Z'
+  };
+
+  const mockUserTrophy = {
+    id: 'user-trophy-123',
+    user_id: 'test-user-id-123',
+    trophy_id: 'trophy-123',
+    earned_at: '2024-01-15T12:00:00Z',
+    progress_data: null,
+    trophy: mockTrophy
+  };
+
+  const mockFollowRelationship = {
+    id: 'follow-123',
+    follower_id: 'test-user-id-123',
+    following_id: 'target-user-id-456',
+    created_at: '2024-01-01T00:00:00Z'
+  };
+
+  const validAuthHeader = 'Bearer valid-jwt-token';
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // =====================================================
+  // GET /api/trophies Tests
+  // =====================================================
+  describe('GET /api/trophies', () => {
+    it('should retrieve all active trophies successfully without authentication', async () => {
+      const mockQuery = {
+        eq: vi.fn(() => mockQuery),
+        order: vi.fn(() => mockQuery)
+      };
+      
+      mockQuery.order.mockResolvedValueOnce({
+        data: [mockTrophy],
+        error: null
+      });
+      
+      const mockSelect = vi.fn(() => mockQuery);
+      (supabase.from as any).mockReturnValue({ select: mockSelect });
+
+      const request = new Request('http://localhost:3000/api/trophies', {
+        method: 'GET'
+      });
+
+      const response = await trophiesHandler(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.success).toBe(true);
+      expect(data.data).toHaveLength(1);
+      expect(data.data[0]).toEqual(mockTrophy);
+      expect(data.message).toBe('Retrieved 1 available trophies');
+    });
+
+    it('should retrieve trophies with valid authentication', async () => {
+      (supabase.auth.getUser as any).mockResolvedValue({
+        data: { user: mockUser },
+        error: null
+      });
+
+      const mockQuery = {
+        eq: vi.fn(() => mockQuery),
+        order: vi.fn(() => mockQuery)
+      };
+      
+      mockQuery.order.mockResolvedValueOnce({
+        data: [mockTrophy],
+        error: null
+      });
+      
+      (supabase.from as any).mockReturnValue({ select: vi.fn(() => mockQuery) });
+
+      const request = new Request('http://localhost:3000/api/trophies', {
+        method: 'GET',
+        headers: { 'Authorization': validAuthHeader }
+      });
+
+      const response = await trophiesHandler(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.success).toBe(true);
+    });
+
+    it('should return 401 for invalid authentication token', async () => {
+      (supabase.auth.getUser as any).mockResolvedValue({
+        data: { user: null },
+        error: { message: 'Invalid token' }
+      });
+
+      const request = new Request('http://localhost:3000/api/trophies', {
+        method: 'GET',
+        headers: { 'Authorization': 'Bearer invalid-token' }
+      });
+
+      const response = await trophiesHandler(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(401);
+      expect(data.success).toBe(false);
+      expect(data.error).toBe('Invalid or expired token');
+    });
+
+    it('should handle database errors gracefully', async () => {
+      const mockQuery = {
+        eq: vi.fn(() => mockQuery),
+        order: vi.fn(() => mockQuery)
+      };
+      
+      mockQuery.order.mockResolvedValueOnce({
+        data: null,
+        error: { message: 'Database connection failed' }
+      });
+      
+      (supabase.from as any).mockReturnValue({ select: vi.fn(() => mockQuery) });
+
+      const request = new Request('http://localhost:3000/api/trophies', {
+        method: 'GET'
+      });
+
+      const response = await trophiesHandler(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(500);
+      expect(data.success).toBe(false);
+      expect(data.error).toBe('Failed to retrieve trophies');
+    });
+
+    it('should return empty array when no trophies exist', async () => {
+      const mockQuery = {
+        eq: vi.fn(() => mockQuery),
+        order: vi.fn(() => mockQuery)
+      };
+      
+      mockQuery.order.mockResolvedValueOnce({
+        data: [],
+        error: null
+      });
+      
+      (supabase.from as any).mockReturnValue({ select: vi.fn(() => mockQuery) });
+
+      const request = new Request('http://localhost:3000/api/trophies', {
+        method: 'GET'
+      });
+
+      const response = await trophiesHandler(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.success).toBe(true);
+      expect(data.data).toHaveLength(0);
+      expect(data.message).toBe('Retrieved 0 available trophies');
+    });
+  });
+
+  // =====================================================
+  // GET /api/users/{userId}/trophies Tests
+  // =====================================================
+  describe('GET /api/users/{userId}/trophies', () => {
+    it('should retrieve user trophies successfully', async () => {
+      // Mock user existence check
+      const mockUserQuery = {
+        eq: vi.fn(() => mockUserQuery),
+        single: vi.fn(() => Promise.resolve({
+          data: mockTargetUser,
+          error: null
+        }))
+      };
+
+      // Mock user trophies query
+      const mockTrophiesQuery = {
+        eq: vi.fn(() => mockTrophiesQuery),
+        order: vi.fn(() => Promise.resolve({
+          data: [mockUserTrophy],
+          error: null
+        }))
+      };
+
+      (supabase.from as any)
+        .mockReturnValueOnce({ select: vi.fn(() => mockUserQuery) }) // User check
+        .mockReturnValueOnce({ select: vi.fn(() => mockTrophiesQuery) }); // Trophies query
+
+      const request = new Request('http://localhost:3000/api/users/target-user-id-456/trophies', {
+        method: 'GET'
+      });
+
+      const response = await userTrophiesHandler(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.success).toBe(true);
+      expect(data.data).toHaveLength(1);
+      expect(data.data[0]).toEqual(mockUserTrophy);
+      expect(data.metadata.total).toBe(1);
+      expect(data.metadata.total_points).toBe(10);
+      expect(data.metadata.rarity_breakdown.common).toBe(1);
+    });
+
+    it('should return 400 for invalid user ID format', async () => {
+      const request = new Request('http://localhost:3000/api/users/invalid-id/trophies', {
+        method: 'GET'
+      });
+
+      const response = await userTrophiesHandler(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(data.success).toBe(false);
+      expect(data.error).toBe('Invalid user ID format');
+    });
+
+    it('should return 404 for non-existent user', async () => {
+      const mockUserQuery = {
+        eq: vi.fn(() => mockUserQuery),
+        single: vi.fn(() => Promise.resolve({
+          data: null,
+          error: { code: 'PGRST116' }
+        }))
+      };
+
+      (supabase.from as any).mockReturnValue({ select: vi.fn(() => mockUserQuery) });
+
+      const request = new Request(`http://localhost:3000/api/users/${mockTargetUser.id}/trophies`, {
+        method: 'GET'
+      });
+
+      const response = await userTrophiesHandler(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(404);
+      expect(data.success).toBe(false);
+      expect(data.error).toBe('User not found');
+    });
+
+    it('should return empty trophies for user with no trophies', async () => {
+      // Mock user existence check
+      const mockUserQuery = {
+        eq: vi.fn(() => mockUserQuery),
+        single: vi.fn(() => Promise.resolve({
+          data: mockTargetUser,
+          error: null
+        }))
+      };
+
+      // Mock empty trophies query
+      const mockTrophiesQuery = {
+        eq: vi.fn(() => mockTrophiesQuery),
+        order: vi.fn(() => Promise.resolve({
+          data: [],
+          error: null
+        }))
+      };
+
+      (supabase.from as any)
+        .mockReturnValueOnce({ select: vi.fn(() => mockUserQuery) })
+        .mockReturnValueOnce({ select: vi.fn(() => mockTrophiesQuery) });
+
+      const request = new Request(`http://localhost:3000/api/users/${mockTargetUser.id}/trophies`, {
+        method: 'GET'
+      });
+
+      const response = await userTrophiesHandler(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.success).toBe(true);
+      expect(data.data).toHaveLength(0);
+      expect(data.metadata.total).toBe(0);
+      expect(data.metadata.total_points).toBe(0);
+    });
+  });
+
+  // =====================================================
+  // POST /api/users/{userId}/follow Tests
+  // =====================================================
+  describe('POST /api/users/{userId}/follow', () => {
+    it('should follow user successfully', async () => {
+      (supabase.auth.getUser as any).mockResolvedValue({
+        data: { user: mockUser },
+        error: null
+      });
+
+      // Mock target user existence check
+      const mockUserQuery = {
+        eq: vi.fn(() => mockUserQuery),
+        single: vi.fn(() => Promise.resolve({
+          data: mockTargetUser,
+          error: null
+        }))
+      };
+
+      // Mock existing follow check (no existing follow)
+      const mockFollowQuery = {
+        eq: vi.fn(() => mockFollowQuery),
+        single: vi.fn(() => Promise.resolve({
+          data: null,
+          error: { code: 'PGRST116' }
+        }))
+      };
+
+      // Mock insert operation
+      const mockInsertQuery = {
+        select: vi.fn(() => ({
+          single: vi.fn(() => Promise.resolve({
+            data: mockFollowRelationship,
+            error: null
+          }))
+        }))
+      };
+
+      (supabase.from as any)
+        .mockReturnValueOnce({ select: vi.fn(() => mockUserQuery) }) // User check
+        .mockReturnValueOnce({ select: vi.fn(() => mockFollowQuery) }) // Existing follow check
+        .mockReturnValueOnce({ insert: vi.fn(() => mockInsertQuery) }); // Insert
+
+      const request = new Request(`http://localhost:3000/api/users/${mockTargetUser.id}/follow`, {
+        method: 'POST',
+        headers: { 'Authorization': validAuthHeader }
+      });
+
+      const response = await followHandler(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(201);
+      expect(data.success).toBe(true);
+      expect(data.data).toEqual(mockFollowRelationship);
+      expect(data.message).toBe('Successfully followed user');
+    });
+
+    it('should return 401 for missing authorization', async () => {
+      const request = new Request(`http://localhost:3000/api/users/${mockTargetUser.id}/follow`, {
+        method: 'POST'
+      });
+
+      const response = await followHandler(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(401);
+      expect(data.success).toBe(false);
+      expect(data.error).toBe('Authorization header required');
+    });
+
+    it('should return 400 for attempting to follow yourself', async () => {
+      (supabase.auth.getUser as any).mockResolvedValue({
+        data: { user: mockUser },
+        error: null
+      });
+
+      const request = new Request(`http://localhost:3000/api/users/${mockUser.id}/follow`, {
+        method: 'POST',
+        headers: { 'Authorization': validAuthHeader }
+      });
+
+      const response = await followHandler(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(data.success).toBe(false);
+      expect(data.error).toBe('Cannot follow yourself');
+    });
+
+    it('should return 404 for non-existent target user', async () => {
+      (supabase.auth.getUser as any).mockResolvedValue({
+        data: { user: mockUser },
+        error: null
+      });
+
+      const mockUserQuery = {
+        eq: vi.fn(() => mockUserQuery),
+        single: vi.fn(() => Promise.resolve({
+          data: null,
+          error: { code: 'PGRST116' }
+        }))
+      };
+
+      (supabase.from as any).mockReturnValue({ select: vi.fn(() => mockUserQuery) });
+
+      const request = new Request(`http://localhost:3000/api/users/${mockTargetUser.id}/follow`, {
+        method: 'POST',
+        headers: { 'Authorization': validAuthHeader }
+      });
+
+      const response = await followHandler(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(404);
+      expect(data.success).toBe(false);
+      expect(data.error).toBe('Target user not found');
+    });
+
+    it('should return 409 for already following user', async () => {
+      (supabase.auth.getUser as any).mockResolvedValue({
+        data: { user: mockUser },
+        error: null
+      });
+
+      // Mock target user existence check
+      const mockUserQuery = {
+        eq: vi.fn(() => mockUserQuery),
+        single: vi.fn(() => Promise.resolve({
+          data: mockTargetUser,
+          error: null
+        }))
+      };
+
+      // Mock existing follow check (already following)
+      const mockFollowQuery = {
+        eq: vi.fn(() => mockFollowQuery),
+        single: vi.fn(() => Promise.resolve({
+          data: mockFollowRelationship,
+          error: null
+        }))
+      };
+
+      (supabase.from as any)
+        .mockReturnValueOnce({ select: vi.fn(() => mockUserQuery) })
+        .mockReturnValueOnce({ select: vi.fn(() => mockFollowQuery) });
+
+      const request = new Request(`http://localhost:3000/api/users/${mockTargetUser.id}/follow`, {
+        method: 'POST',
+        headers: { 'Authorization': validAuthHeader }
+      });
+
+      const response = await followHandler(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(409);
+      expect(data.success).toBe(false);
+      expect(data.error).toBe('Already following this user');
+    });
+  });
+
+  // =====================================================
+  // DELETE /api/users/{userId}/follow Tests
+  // =====================================================
+  describe('DELETE /api/users/{userId}/follow', () => {
+    it('should unfollow user successfully', async () => {
+      (supabase.auth.getUser as any).mockResolvedValue({
+        data: { user: mockUser },
+        error: null
+      });
+
+      // Mock existing follow check (currently following)
+      const mockFollowQuery = {
+        eq: vi.fn(() => mockFollowQuery),
+        single: vi.fn(() => Promise.resolve({
+          data: mockFollowRelationship,
+          error: null
+        }))
+      };
+
+      // Mock delete operation
+      const mockDeleteQuery = {
+        eq: vi.fn(() => Promise.resolve({
+          error: null
+        }))
+      };
+
+      (supabase.from as any)
+        .mockReturnValueOnce({ select: vi.fn(() => mockFollowQuery) }) // Follow check
+        .mockReturnValueOnce({ delete: vi.fn(() => mockDeleteQuery) }); // Delete
+
+      const request = new Request(`http://localhost:3000/api/users/${mockTargetUser.id}/follow`, {
+        method: 'DELETE',
+        headers: { 'Authorization': validAuthHeader }
+      });
+
+      const response = await followHandler(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.success).toBe(true);
+      expect(data.message).toBe('Successfully unfollowed user');
+    });
+
+    it('should return 404 for not currently following user', async () => {
+      (supabase.auth.getUser as any).mockResolvedValue({
+        data: { user: mockUser },
+        error: null
+      });
+
+      const mockFollowQuery = {
+        eq: vi.fn(() => mockFollowQuery),
+        single: vi.fn(() => Promise.resolve({
+          data: null,
+          error: { code: 'PGRST116' }
+        }))
+      };
+
+      (supabase.from as any).mockReturnValue({ select: vi.fn(() => mockFollowQuery) });
+
+      const request = new Request(`http://localhost:3000/api/users/${mockTargetUser.id}/follow`, {
+        method: 'DELETE',
+        headers: { 'Authorization': validAuthHeader }
+      });
+
+      const response = await followHandler(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(404);
+      expect(data.success).toBe(false);
+      expect(data.error).toBe('Not currently following this user');
+    });
+
+    it('should return 400 for attempting to unfollow yourself', async () => {
+      (supabase.auth.getUser as any).mockResolvedValue({
+        data: { user: mockUser },
+        error: null
+      });
+
+      const request = new Request(`http://localhost:3000/api/users/${mockUser.id}/follow`, {
+        method: 'DELETE',
+        headers: { 'Authorization': validAuthHeader }
+      });
+
+      const response = await followHandler(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(data.success).toBe(false);
+      expect(data.error).toBe('Cannot unfollow yourself');
+    });
+  });
+
+  // =====================================================
+  // CORS and Method Validation Tests
+  // =====================================================
+  describe('CORS and Method Validation', () => {
+    it('should handle OPTIONS requests for trophies endpoint', async () => {
+      const request = new Request('http://localhost:3000/api/trophies', {
+        method: 'OPTIONS'
+      });
+
+      const response = await trophiesHandler(request);
+
+      expect(response.status).toBe(200);
+      expect(response.headers.get('Access-Control-Allow-Origin')).toBe('*');
+      expect(response.headers.get('Access-Control-Allow-Methods')).toContain('GET');
+    });
+
+    it('should handle OPTIONS requests for user trophies endpoint', async () => {
+      const request = new Request(`http://localhost:3000/api/users/${mockTargetUser.id}/trophies`, {
+        method: 'OPTIONS'
+      });
+
+      const response = await userTrophiesHandler(request);
+
+      expect(response.status).toBe(200);
+      expect(response.headers.get('Access-Control-Allow-Origin')).toBe('*');
+      expect(response.headers.get('Access-Control-Allow-Methods')).toContain('GET');
+    });
+
+    it('should handle OPTIONS requests for follow endpoint', async () => {
+      const request = new Request(`http://localhost:3000/api/users/${mockTargetUser.id}/follow`, {
+        method: 'OPTIONS'
+      });
+
+      const response = await followHandler(request);
+
+      expect(response.status).toBe(200);
+      expect(response.headers.get('Access-Control-Allow-Origin')).toBe('*');
+      expect(response.headers.get('Access-Control-Allow-Methods')).toContain('POST');
+      expect(response.headers.get('Access-Control-Allow-Methods')).toContain('DELETE');
+    });
+
+    it('should return 405 for unsupported methods on trophies endpoint', async () => {
+      const request = new Request('http://localhost:3000/api/trophies', {
+        method: 'POST'
+      });
+
+      const response = await trophiesHandler(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(405);
+      expect(data.success).toBe(false);
+      expect(data.error).toBe('Method not allowed');
+    });
+
+    it('should return 405 for unsupported methods on user trophies endpoint', async () => {
+      const request = new Request(`http://localhost:3000/api/users/${mockTargetUser.id}/trophies`, {
+        method: 'POST'
+      });
+
+      const response = await userTrophiesHandler(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(405);
+      expect(data.success).toBe(false);
+      expect(data.error).toBe('Method not allowed');
+    });
+
+    it('should return 405 for unsupported methods on follow endpoint', async () => {
+      const request = new Request(`http://localhost:3000/api/users/${mockTargetUser.id}/follow`, {
+        method: 'GET'
+      });
+
+      const response = await followHandler(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(405);
+      expect(data.success).toBe(false);
+      expect(data.error).toBe('Method not allowed');
+    });
+  });
+
+  describe('URL Path Parsing', () => {
+    it('should return 400 when userId is missing from trophies URL', async () => {
+      const request = new Request('http://localhost:3000/api/users//trophies', {
+        method: 'GET'
+      });
+
+      const response = await userTrophiesHandler(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(data.success).toBe(false);
+      expect(data.error).toBe('User ID is required');
+    });
+
+    it('should return 400 when userId is missing from follow URL', async () => {
+      const request = new Request('http://localhost:3000/api/users//follow', {
+        method: 'POST',
+        headers: { 'Authorization': validAuthHeader }
+      });
+
+      const response = await followHandler(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(data.success).toBe(false);
+      expect(data.error).toBe('User ID is required');
+    });
+  });
+});

--- a/src/pages/api/trophies.ts
+++ b/src/pages/api/trophies.ts
@@ -1,0 +1,137 @@
+import { supabase } from '../../lib/supabaseClient';
+
+interface Trophy {
+  id: string;
+  name: string;
+  description: string;
+  category: string;
+  icon?: string;
+  rarity: string;
+  points: number;
+  requirements?: any;
+  is_active: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
+interface ApiResponse<T = any> {
+  success: boolean;
+  data?: T;
+  error?: string;
+  message?: string;
+}
+
+/**
+ * Extract and validate JWT token from Authorization header
+ */
+async function validateAuthToken(request: Request): Promise<{ user: any; error?: string }> {
+  const authHeader = request.headers.get('Authorization');
+  
+  if (!authHeader || !authHeader.startsWith('Bearer ')) {
+    return { user: null, error: 'Authorization header required' };
+  }
+
+  const token = authHeader.substring(7);
+  
+  try {
+    const { data: { user }, error } = await supabase.auth.getUser(token);
+    
+    if (error || !user) {
+      return { user: null, error: 'Invalid or expired token' };
+    }
+    
+    return { user };
+  } catch (error) {
+    return { user: null, error: 'Token validation failed' };
+  }
+}
+
+/**
+ * GET /api/trophies - Retrieve all available trophies in the system
+ */
+async function handleGetTrophies(request: Request): Promise<Response> {
+  // Authentication is optional for viewing trophies - they're publicly available
+  // But we'll validate the token if provided for potential future features
+  const { user, error: authError } = await validateAuthToken(request);
+  
+  // Don't fail if no auth token provided - trophies are public
+  if (authError && authError !== 'Authorization header required') {
+    return new Response(
+      JSON.stringify({ success: false, error: authError }),
+      { status: 401, headers: { 'Content-Type': 'application/json' } }
+    );
+  }
+
+  try {
+    const { data, error } = await supabase
+      .from('trophies')
+      .select('*')
+      .eq('is_active', true)
+      .order('category', { ascending: true })
+      .order('rarity', { ascending: false })
+      .order('points', { ascending: false });
+
+    if (error) {
+      console.error('Database error:', error);
+      return new Response(
+        JSON.stringify({ success: false, error: 'Failed to retrieve trophies' }),
+        { status: 500, headers: { 'Content-Type': 'application/json' } }
+      );
+    }
+
+    return new Response(
+      JSON.stringify({
+        success: true,
+        data: data || [],
+        message: `Retrieved ${data?.length || 0} available trophies`
+      }),
+      { status: 200, headers: { 'Content-Type': 'application/json' } }
+    );
+
+  } catch (error) {
+    console.error('API Error in GET /api/trophies:', error);
+    return new Response(
+      JSON.stringify({ success: false, error: 'Internal server error' }),
+      { status: 500, headers: { 'Content-Type': 'application/json' } }
+    );
+  }
+}
+
+/**
+ * Main API handler for /api/trophies
+ */
+export async function handler(request: Request): Promise<Response> {
+  try {
+    // Handle CORS preflight requests
+    if (request.method === 'OPTIONS') {
+      return new Response(null, {
+        status: 200,
+        headers: {
+          'Access-Control-Allow-Origin': '*',
+          'Access-Control-Allow-Methods': 'GET, OPTIONS',
+          'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+        },
+      });
+    }
+
+    switch (request.method) {
+      case 'GET':
+        return handleGetTrophies(request);
+      default:
+        return new Response(
+          JSON.stringify({ success: false, error: 'Method not allowed' }),
+          { status: 405, headers: { 'Content-Type': 'application/json' } }
+        );
+    }
+  } catch (error) {
+    console.error('API Error in /api/trophies:', error);
+    return new Response(
+      JSON.stringify({ success: false, error: 'Internal server error' }),
+      { status: 500, headers: { 'Content-Type': 'application/json' } }
+    );
+  }
+}
+
+// Export for different runtime environments
+export default handler;
+export { handler as GET };

--- a/src/pages/api/users/[userId]/follow.ts
+++ b/src/pages/api/users/[userId]/follow.ts
@@ -1,0 +1,290 @@
+import { supabase } from '../../../../lib/supabaseClient';
+
+interface FollowRequest {
+  // No body needed for follow/unfollow - userId is in URL
+}
+
+interface ApiResponse<T = any> {
+  success: boolean;
+  data?: T;
+  error?: string;
+  message?: string;
+}
+
+/**
+ * Extract and validate JWT token from Authorization header
+ */
+async function validateAuthToken(request: Request): Promise<{ user: any; error?: string }> {
+  const authHeader = request.headers.get('Authorization');
+  
+  if (!authHeader || !authHeader.startsWith('Bearer ')) {
+    return { user: null, error: 'Authorization header required' };
+  }
+
+  const token = authHeader.substring(7);
+  
+  try {
+    const { data: { user }, error } = await supabase.auth.getUser(token);
+    
+    if (error || !user) {
+      return { user: null, error: 'Invalid or expired token' };
+    }
+    
+    return { user };
+  } catch (error) {
+    return { user: null, error: 'Token validation failed' };
+  }
+}
+
+/**
+ * Extract userId from URL path
+ */
+function extractUserIdFromPath(url: string): string | null {
+  const match = url.match(/\/api\/users\/([^\/]+)\/follow/);
+  return match ? match[1] : null;
+}
+
+/**
+ * Validate UUID format
+ */
+function isValidUUID(uuid: string): boolean {
+  const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+  return uuidRegex.test(uuid);
+}
+
+/**
+ * POST /api/users/{userId}/follow - Follow a user
+ */
+async function handleFollowUser(request: Request): Promise<Response> {
+  const { user, error: authError } = await validateAuthToken(request);
+  
+  if (authError || !user) {
+    return new Response(
+      JSON.stringify({ success: false, error: authError || 'Unauthorized' }),
+      { status: 401, headers: { 'Content-Type': 'application/json' } }
+    );
+  }
+
+  // Extract userId from URL
+  const targetUserId = extractUserIdFromPath(request.url);
+  
+  if (!targetUserId) {
+    return new Response(
+      JSON.stringify({ success: false, error: 'User ID is required' }),
+      { status: 400, headers: { 'Content-Type': 'application/json' } }
+    );
+  }
+
+  if (!isValidUUID(targetUserId)) {
+    return new Response(
+      JSON.stringify({ success: false, error: 'Invalid user ID format' }),
+      { status: 400, headers: { 'Content-Type': 'application/json' } }
+    );
+  }
+
+  // Prevent self-following
+  if (user.id === targetUserId) {
+    return new Response(
+      JSON.stringify({ success: false, error: 'Cannot follow yourself' }),
+      { status: 400, headers: { 'Content-Type': 'application/json' } }
+    );
+  }
+
+  try {
+    // First verify the target user exists
+    const { data: targetUser, error: userError } = await supabase
+      .from('users')
+      .select('id')
+      .eq('id', targetUserId)
+      .single();
+
+    if (userError || !targetUser) {
+      return new Response(
+        JSON.stringify({ success: false, error: 'Target user not found' }),
+        { status: 404, headers: { 'Content-Type': 'application/json' } }
+      );
+    }
+
+    // Check if already following
+    const { data: existingFollow } = await supabase
+      .from('user_follows')
+      .select('id')
+      .eq('follower_id', user.id)
+      .eq('following_id', targetUserId)
+      .single();
+
+    if (existingFollow) {
+      return new Response(
+        JSON.stringify({ 
+          success: false, 
+          error: 'Already following this user' 
+        }),
+        { status: 409, headers: { 'Content-Type': 'application/json' } }
+      );
+    }
+
+    // Create follow relationship
+    const { data, error } = await supabase
+      .from('user_follows')
+      .insert({
+        follower_id: user.id,
+        following_id: targetUserId
+      })
+      .select()
+      .single();
+
+    if (error) {
+      console.error('Database error:', error);
+      return new Response(
+        JSON.stringify({ success: false, error: 'Failed to follow user' }),
+        { status: 500, headers: { 'Content-Type': 'application/json' } }
+      );
+    }
+
+    return new Response(
+      JSON.stringify({
+        success: true,
+        data,
+        message: 'Successfully followed user'
+      }),
+      { status: 201, headers: { 'Content-Type': 'application/json' } }
+    );
+
+  } catch (error) {
+    console.error('API Error in POST /api/users/{userId}/follow:', error);
+    return new Response(
+      JSON.stringify({ success: false, error: 'Internal server error' }),
+      { status: 500, headers: { 'Content-Type': 'application/json' } }
+    );
+  }
+}
+
+/**
+ * DELETE /api/users/{userId}/follow - Unfollow a user
+ */
+async function handleUnfollowUser(request: Request): Promise<Response> {
+  const { user, error: authError } = await validateAuthToken(request);
+  
+  if (authError || !user) {
+    return new Response(
+      JSON.stringify({ success: false, error: authError || 'Unauthorized' }),
+      { status: 401, headers: { 'Content-Type': 'application/json' } }
+    );
+  }
+
+  // Extract userId from URL
+  const targetUserId = extractUserIdFromPath(request.url);
+  
+  if (!targetUserId) {
+    return new Response(
+      JSON.stringify({ success: false, error: 'User ID is required' }),
+      { status: 400, headers: { 'Content-Type': 'application/json' } }
+    );
+  }
+
+  if (!isValidUUID(targetUserId)) {
+    return new Response(
+      JSON.stringify({ success: false, error: 'Invalid user ID format' }),
+      { status: 400, headers: { 'Content-Type': 'application/json' } }
+    );
+  }
+
+  // Prevent self-unfollowing (shouldn't happen, but safety check)
+  if (user.id === targetUserId) {
+    return new Response(
+      JSON.stringify({ success: false, error: 'Cannot unfollow yourself' }),
+      { status: 400, headers: { 'Content-Type': 'application/json' } }
+    );
+  }
+
+  try {
+    // Check if currently following
+    const { data: existingFollow } = await supabase
+      .from('user_follows')
+      .select('id')
+      .eq('follower_id', user.id)
+      .eq('following_id', targetUserId)
+      .single();
+
+    if (!existingFollow) {
+      return new Response(
+        JSON.stringify({ 
+          success: false, 
+          error: 'Not currently following this user' 
+        }),
+        { status: 404, headers: { 'Content-Type': 'application/json' } }
+      );
+    }
+
+    // Remove follow relationship
+    const { error } = await supabase
+      .from('user_follows')
+      .delete()
+      .eq('follower_id', user.id)
+      .eq('following_id', targetUserId);
+
+    if (error) {
+      console.error('Database error:', error);
+      return new Response(
+        JSON.stringify({ success: false, error: 'Failed to unfollow user' }),
+        { status: 500, headers: { 'Content-Type': 'application/json' } }
+      );
+    }
+
+    return new Response(
+      JSON.stringify({
+        success: true,
+        message: 'Successfully unfollowed user'
+      }),
+      { status: 200, headers: { 'Content-Type': 'application/json' } }
+    );
+
+  } catch (error) {
+    console.error('API Error in DELETE /api/users/{userId}/follow:', error);
+    return new Response(
+      JSON.stringify({ success: false, error: 'Internal server error' }),
+      { status: 500, headers: { 'Content-Type': 'application/json' } }
+    );
+  }
+}
+
+/**
+ * Main API handler for /api/users/{userId}/follow
+ */
+export async function handler(request: Request): Promise<Response> {
+  try {
+    // Handle CORS preflight requests
+    if (request.method === 'OPTIONS') {
+      return new Response(null, {
+        status: 200,
+        headers: {
+          'Access-Control-Allow-Origin': '*',
+          'Access-Control-Allow-Methods': 'POST, DELETE, OPTIONS',
+          'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+        },
+      });
+    }
+
+    switch (request.method) {
+      case 'POST':
+        return handleFollowUser(request);
+      case 'DELETE':
+        return handleUnfollowUser(request);
+      default:
+        return new Response(
+          JSON.stringify({ success: false, error: 'Method not allowed' }),
+          { status: 405, headers: { 'Content-Type': 'application/json' } }
+        );
+    }
+  } catch (error) {
+    console.error('API Error in /api/users/{userId}/follow:', error);
+    return new Response(
+      JSON.stringify({ success: false, error: 'Internal server error' }),
+      { status: 500, headers: { 'Content-Type': 'application/json' } }
+    );
+  }
+}
+
+// Export for different runtime environments
+export default handler;
+export { handler as POST, handler as DELETE };

--- a/src/pages/api/users/[userId]/trophies.ts
+++ b/src/pages/api/users/[userId]/trophies.ts
@@ -1,0 +1,224 @@
+import { supabase } from '../../../../lib/supabaseClient';
+
+interface UserTrophy {
+  id: string;
+  user_id: string;
+  trophy_id: string;
+  earned_at: string;
+  progress_data?: any;
+  trophy: {
+    id: string;
+    name: string;
+    description: string;
+    category: string;
+    icon?: string;
+    rarity: string;
+    points: number;
+    requirements?: any;
+  };
+}
+
+interface ApiResponse<T = any> {
+  success: boolean;
+  data?: T;
+  error?: string;
+  message?: string;
+  metadata?: {
+    total?: number;
+    total_points?: number;
+    rarity_breakdown?: {
+      common: number;
+      rare: number;
+      epic: number;
+      legendary: number;
+    };
+  };
+}
+
+/**
+ * Extract and validate JWT token from Authorization header
+ */
+async function validateAuthToken(request: Request): Promise<{ user: any; error?: string }> {
+  const authHeader = request.headers.get('Authorization');
+  
+  if (!authHeader || !authHeader.startsWith('Bearer ')) {
+    return { user: null, error: 'Authorization header required' };
+  }
+
+  const token = authHeader.substring(7);
+  
+  try {
+    const { data: { user }, error } = await supabase.auth.getUser(token);
+    
+    if (error || !user) {
+      return { user: null, error: 'Invalid or expired token' };
+    }
+    
+    return { user };
+  } catch (error) {
+    return { user: null, error: 'Token validation failed' };
+  }
+}
+
+/**
+ * Extract userId from URL path
+ */
+function extractUserIdFromPath(url: string): string | null {
+  const match = url.match(/\/api\/users\/([^\/]+)\/trophies/);
+  return match ? match[1] : null;
+}
+
+/**
+ * Validate UUID format
+ */
+function isValidUUID(uuid: string): boolean {
+  const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+  return uuidRegex.test(uuid);
+}
+
+/**
+ * GET /api/users/{userId}/trophies - Retrieve the trophies a specific user has earned
+ */
+async function handleGetUserTrophies(request: Request): Promise<Response> {
+  // Auth is optional for viewing others' trophies (public social feature)
+  // but we'll validate if provided
+  const { user, error: authError } = await validateAuthToken(request);
+  
+  // Don't fail if no auth token - trophy viewing could be public
+  if (authError && authError !== 'Authorization header required') {
+    return new Response(
+      JSON.stringify({ success: false, error: authError }),
+      { status: 401, headers: { 'Content-Type': 'application/json' } }
+    );
+  }
+
+  // Extract userId from URL
+  const userId = extractUserIdFromPath(request.url);
+  
+  if (!userId) {
+    return new Response(
+      JSON.stringify({ success: false, error: 'User ID is required' }),
+      { status: 400, headers: { 'Content-Type': 'application/json' } }
+    );
+  }
+
+  if (!isValidUUID(userId)) {
+    return new Response(
+      JSON.stringify({ success: false, error: 'Invalid user ID format' }),
+      { status: 400, headers: { 'Content-Type': 'application/json' } }
+    );
+  }
+
+  try {
+    // First verify the user exists
+    const { data: targetUser, error: userError } = await supabase
+      .from('users')
+      .select('id')
+      .eq('id', userId)
+      .single();
+
+    if (userError || !targetUser) {
+      return new Response(
+        JSON.stringify({ success: false, error: 'User not found' }),
+        { status: 404, headers: { 'Content-Type': 'application/json' } }
+      );
+    }
+
+    // Get user trophies with trophy details
+    const { data, error } = await supabase
+      .from('user_trophies')
+      .select(`
+        *,
+        trophy:trophies(
+          id,
+          name,
+          description,
+          category,
+          icon,
+          rarity,
+          points,
+          requirements
+        )
+      `)
+      .eq('user_id', userId)
+      .order('earned_at', { ascending: false });
+
+    if (error) {
+      console.error('Database error:', error);
+      return new Response(
+        JSON.stringify({ success: false, error: 'Failed to retrieve user trophies' }),
+        { status: 500, headers: { 'Content-Type': 'application/json' } }
+      );
+    }
+
+    // Calculate trophy statistics
+    const trophies = data || [];
+    const totalPoints = trophies.reduce((sum, ut) => sum + (ut.trophy?.points || 0), 0);
+    const rarityBreakdown = {
+      common: trophies.filter(ut => ut.trophy?.rarity === 'common').length,
+      rare: trophies.filter(ut => ut.trophy?.rarity === 'rare').length,
+      epic: trophies.filter(ut => ut.trophy?.rarity === 'epic').length,
+      legendary: trophies.filter(ut => ut.trophy?.rarity === 'legendary').length,
+    };
+
+    return new Response(
+      JSON.stringify({
+        success: true,
+        data: trophies,
+        message: `Retrieved ${trophies.length} trophies for user`,
+        metadata: {
+          total: trophies.length,
+          total_points: totalPoints,
+          rarity_breakdown: rarityBreakdown
+        }
+      }),
+      { status: 200, headers: { 'Content-Type': 'application/json' } }
+    );
+
+  } catch (error) {
+    console.error('API Error in GET /api/users/{userId}/trophies:', error);
+    return new Response(
+      JSON.stringify({ success: false, error: 'Internal server error' }),
+      { status: 500, headers: { 'Content-Type': 'application/json' } }
+    );
+  }
+}
+
+/**
+ * Main API handler for /api/users/{userId}/trophies
+ */
+export async function handler(request: Request): Promise<Response> {
+  try {
+    // Handle CORS preflight requests
+    if (request.method === 'OPTIONS') {
+      return new Response(null, {
+        status: 200,
+        headers: {
+          'Access-Control-Allow-Origin': '*',
+          'Access-Control-Allow-Methods': 'GET, OPTIONS',
+          'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+        },
+      });
+    }
+
+    switch (request.method) {
+      case 'GET':
+        return handleGetUserTrophies(request);
+      default:
+        return new Response(
+          JSON.stringify({ success: false, error: 'Method not allowed' }),
+          { status: 405, headers: { 'Content-Type': 'application/json' } }
+        );
+    }
+  } catch (error) {
+    console.error('API Error in /api/users/{userId}/trophies:', error);
+    return new Response(
+      JSON.stringify({ success: false, error: 'Internal server error' }),
+      { status: 500, headers: { 'Content-Type': 'application/json' } }
+    );
+  }
+}
+
+// Export for different runtime environments
+export default handler;
+export { handler as GET };

--- a/supabase/migrations/006_gamification_social.sql
+++ b/supabase/migrations/006_gamification_social.sql
@@ -1,0 +1,220 @@
+-- =====================================================
+-- Phase 6: Gamification & Social Features
+-- File: 006_gamification_social.sql
+-- Description: Add trophy system and social features (user following)
+-- =====================================================
+
+-- =====================================================
+-- TROPHY SYSTEM TABLES
+-- =====================================================
+
+-- Trophies table - defines all available achievements
+CREATE TABLE IF NOT EXISTS trophies (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    name TEXT NOT NULL UNIQUE,
+    description TEXT NOT NULL,
+    category TEXT NOT NULL, -- 'collection', 'trading', 'social', 'milestone'
+    icon TEXT, -- Icon identifier for UI
+    rarity TEXT NOT NULL DEFAULT 'common', -- 'common', 'rare', 'epic', 'legendary'
+    points INTEGER DEFAULT 10, -- Points awarded when earned
+    requirements JSONB, -- Flexible requirements structure
+    is_active BOOLEAN DEFAULT TRUE,
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    updated_at TIMESTAMPTZ DEFAULT NOW(),
+    
+    -- Constraints
+    CONSTRAINT chk_trophy_category CHECK (category IN ('collection', 'trading', 'social', 'milestone')),
+    CONSTRAINT chk_trophy_rarity CHECK (rarity IN ('common', 'rare', 'epic', 'legendary')),
+    CONSTRAINT chk_trophy_points CHECK (points >= 0)
+);
+
+-- User trophies table - tracks which users have earned which trophies
+CREATE TABLE IF NOT EXISTS user_trophies (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    trophy_id UUID NOT NULL REFERENCES trophies(id) ON DELETE CASCADE,
+    earned_at TIMESTAMPTZ DEFAULT NOW(),
+    progress_data JSONB, -- Store progress information if needed
+    
+    -- Ensure users can only earn each trophy once
+    UNIQUE(user_id, trophy_id)
+);
+
+-- =====================================================
+-- SOCIAL FEATURES TABLES
+-- =====================================================
+
+-- User follows table - tracks who follows whom
+CREATE TABLE IF NOT EXISTS user_follows (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    follower_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    following_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    
+    -- Ensure unique follow relationships and prevent self-following
+    UNIQUE(follower_id, following_id),
+    CONSTRAINT chk_no_self_follow CHECK (follower_id != following_id)
+);
+
+-- =====================================================
+-- SEED INITIAL TROPHY DATA
+-- =====================================================
+
+INSERT INTO trophies (name, description, category, icon, rarity, points, requirements) VALUES
+-- Collection Milestones
+('First Comic', 'Add your first comic to your collection', 'collection', 'trophy', 'common', 10, '{"type": "collection_count", "threshold": 1}'),
+('Growing Collection', 'Collect 10 different comics', 'collection', 'medal', 'common', 25, '{"type": "collection_count", "threshold": 10}'),
+('Serious Collector', 'Collect 50 different comics', 'collection', 'award', 'rare', 100, '{"type": "collection_count", "threshold": 50}'),
+('Comic Connoisseur', 'Collect 100 different comics', 'collection', 'star', 'epic', 250, '{"type": "collection_count", "threshold": 100}'),
+('Master Collector', 'Collect 500 different comics', 'collection', 'crown', 'legendary', 1000, '{"type": "collection_count", "threshold": 500}'),
+
+-- Key Issue Milestones
+('Key Issue Hunter', 'Collect your first key issue', 'collection', 'key', 'rare', 50, '{"type": "key_issue_count", "threshold": 1}'),
+('Key Issue Expert', 'Collect 10 key issues', 'collection', 'gem', 'epic', 200, '{"type": "key_issue_count", "threshold": 10}'),
+
+-- Grading Milestones
+('Graded Guardian', 'Collect your first graded comic', 'collection', 'shield', 'rare', 75, '{"type": "graded_count", "threshold": 1}'),
+
+-- Social Milestones
+('First Friend', 'Follow your first user', 'social', 'users', 'common', 15, '{"type": "following_count", "threshold": 1}'),
+('Social Butterfly', 'Follow 10 users', 'social', 'heart', 'rare', 50, '{"type": "following_count", "threshold": 10}'),
+('Popular Collector', 'Gain 10 followers', 'social', 'trending-up', 'rare', 75, '{"type": "followers_count", "threshold": 10}'),
+('Community Leader', 'Gain 50 followers', 'social', 'users-2', 'epic', 300, '{"type": "followers_count", "threshold": 50}'),
+
+-- Trading Milestones  
+('Deal Hunter', 'Find your first great deal (score > 70)', 'trading', 'target', 'common', 20, '{"type": "deal_score", "threshold": 70}'),
+('Bargain Master', 'Find 10 great deals (score > 70)', 'trading', 'zap', 'rare', 100, '{"type": "deal_count", "threshold": 10, "min_score": 70}'),
+
+-- Value Milestones
+('Growing Investment', 'Have a collection worth over £1,000', 'milestone', 'trending-up', 'rare', 100, '{"type": "collection_value", "threshold": 1000}'),
+('Serious Investment', 'Have a collection worth over £5,000', 'milestone', 'bar-chart', 'epic', 500, '{"type": "collection_value", "threshold": 5000}'),
+('Major Investment', 'Have a collection worth over £10,000', 'milestone', 'diamond', 'legendary', 1000, '{"type": "collection_value", "threshold": 10000}');
+
+-- =====================================================
+-- INDEXES FOR PERFORMANCE
+-- =====================================================
+
+-- Trophy indexes
+CREATE INDEX IF NOT EXISTS idx_trophies_category ON trophies (category);
+CREATE INDEX IF NOT EXISTS idx_trophies_rarity ON trophies (rarity);
+CREATE INDEX IF NOT EXISTS idx_trophies_active ON trophies (is_active) WHERE is_active = TRUE;
+
+-- User trophies indexes
+CREATE INDEX IF NOT EXISTS idx_user_trophies_user_id ON user_trophies (user_id);
+CREATE INDEX IF NOT EXISTS idx_user_trophies_trophy_id ON user_trophies (trophy_id);
+CREATE INDEX IF NOT EXISTS idx_user_trophies_earned_at ON user_trophies (earned_at DESC);
+
+-- User follows indexes
+CREATE INDEX IF NOT EXISTS idx_user_follows_follower_id ON user_follows (follower_id);
+CREATE INDEX IF NOT EXISTS idx_user_follows_following_id ON user_follows (following_id);
+CREATE INDEX IF NOT EXISTS idx_user_follows_created_at ON user_follows (created_at DESC);
+
+-- =====================================================
+-- ROW LEVEL SECURITY POLICIES
+-- =====================================================
+
+-- Enable RLS on trophy tables
+ALTER TABLE trophies ENABLE ROW LEVEL SECURITY;
+ALTER TABLE user_trophies ENABLE ROW LEVEL SECURITY;
+ALTER TABLE user_follows ENABLE ROW LEVEL SECURITY;
+
+-- Trophies policies - everyone can read trophies
+CREATE POLICY "Anyone can view trophies"
+    ON trophies FOR SELECT
+    USING (is_active = TRUE);
+
+-- User trophies policies - users can view their own trophies
+CREATE POLICY "Users can view their own trophies"
+    ON user_trophies FOR SELECT
+    USING (auth.uid() = user_id);
+
+CREATE POLICY "Users can view others' trophies"
+    ON user_trophies FOR SELECT
+    USING (TRUE); -- Allow viewing other users' trophies for social features
+
+-- Only system can insert/update trophies (this would be handled by functions)
+CREATE POLICY "System can manage user trophies"
+    ON user_trophies FOR ALL
+    USING (auth.uid() IS NOT NULL); -- Authenticated users (system operations)
+
+-- User follows policies
+CREATE POLICY "Users can view follows"
+    ON user_follows FOR SELECT
+    USING (TRUE); -- Allow viewing follow relationships for social features
+
+CREATE POLICY "Users can follow others"
+    ON user_follows FOR INSERT
+    WITH CHECK (auth.uid() = follower_id);
+
+CREATE POLICY "Users can unfollow others"
+    ON user_follows FOR DELETE
+    USING (auth.uid() = follower_id);
+
+-- =====================================================
+-- HELPER FUNCTIONS
+-- =====================================================
+
+-- Function to get user's trophy count and total points
+CREATE OR REPLACE FUNCTION get_user_trophy_stats(p_user_id UUID)
+RETURNS TABLE (
+    total_trophies BIGINT,
+    total_points BIGINT,
+    common_count BIGINT,
+    rare_count BIGINT,
+    epic_count BIGINT,
+    legendary_count BIGINT
+) AS $$
+BEGIN
+    RETURN QUERY
+    SELECT 
+        COUNT(*) as total_trophies,
+        COALESCE(SUM(t.points), 0) as total_points,
+        COUNT(*) FILTER (WHERE t.rarity = 'common') as common_count,
+        COUNT(*) FILTER (WHERE t.rarity = 'rare') as rare_count,
+        COUNT(*) FILTER (WHERE t.rarity = 'epic') as epic_count,
+        COUNT(*) FILTER (WHERE t.rarity = 'legendary') as legendary_count
+    FROM user_trophies ut
+    JOIN trophies t ON ut.trophy_id = t.id
+    WHERE ut.user_id = p_user_id;
+END;
+$$ LANGUAGE plpgsql STABLE SECURITY DEFINER;
+
+-- Function to get user's social stats
+CREATE OR REPLACE FUNCTION get_user_social_stats(p_user_id UUID)
+RETURNS TABLE (
+    followers_count BIGINT,
+    following_count BIGINT
+) AS $$
+BEGIN
+    RETURN QUERY
+    SELECT 
+        (SELECT COUNT(*) FROM user_follows WHERE following_id = p_user_id) as followers_count,
+        (SELECT COUNT(*) FROM user_follows WHERE follower_id = p_user_id) as following_count;
+END;
+$$ LANGUAGE plpgsql STABLE SECURITY DEFINER;
+
+-- =====================================================
+-- UPDATE TRIGGERS
+-- =====================================================
+
+-- Update trigger for trophies table
+CREATE TRIGGER update_trophies_updated_at
+    BEFORE UPDATE ON trophies
+    FOR EACH ROW EXECUTE FUNCTION update_updated_at();
+
+-- =====================================================
+-- GRANT PERMISSIONS
+-- =====================================================
+
+-- Grant permissions to authenticated users
+GRANT SELECT ON trophies TO authenticated;
+GRANT SELECT ON user_trophies TO authenticated;
+GRANT SELECT, INSERT, DELETE ON user_follows TO authenticated;
+
+-- Grant execute permissions on functions
+GRANT EXECUTE ON FUNCTION get_user_trophy_stats(UUID) TO authenticated;
+GRANT EXECUTE ON FUNCTION get_user_social_stats(UUID) TO authenticated;
+
+-- Log completion
+INSERT INTO migration_log (migration_file, status, completed_at) 
+VALUES ('006_gamification_social.sql', 'completed', NOW());


### PR DESCRIPTION
Add the final API endpoints for gamification and social features as requested in issue #61.

## Changes
- Database migration for trophy system and user following
- GET /api/trophies endpoint
- GET /api/users/{userId}/trophies endpoint
- POST /api/users/{userId}/follow endpoint
- DELETE /api/users/{userId}/follow endpoint
- Comprehensive vitest tests for all endpoints

Closes #61

Generated with [Claude Code](https://claude.ai/code)