### PR TITLE
fix: Convert user prop from null to undefined for MainNavbar

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,7 +21,7 @@ function App() {
     <div className="min-h-screen bg-parchment flex flex-col">
       {/* Main Navigation */}
       <MainNavbar 
-        user={user}
+        user={user || undefined}
         onNavigate={(page) => console.log('Navigate to:', page)}
         onLogout={() => console.log('Logout')}
         notificationCount={3}


### PR DESCRIPTION
Fixes #103

This PR resolves the TypeScript error TS2322 that was causing Vercel deployment to fail.

## Changes
- Fixed type mismatch in src/App.tsx line 24
- Changed `user={user}` to `user={user || undefined}`
- Converts null values to undefined as expected by MainNavbar component

Generated with [Claude Code](https://claude.ai/code)