### PR TITLE
feat: Add session persistence to user store

### DIFF
--- a/src/store/userStore.ts
+++ b/src/store/userStore.ts
@@ -1,4 +1,5 @@
 import { create } from 'zustand'
+import { persist } from 'zustand/middleware'
 
 interface NavbarUserType {
   name: string
@@ -14,10 +15,17 @@ interface UserStore {
   setLoading: (loading: boolean) => void
 }
 
-export const useUserStore = create<UserStore>((set) => ({
-  user: null,
-  isLoading: false,
-  setUser: (user) => set({ user }),
-  clearUser: () => set({ user: null }),
-  setLoading: (isLoading) => set({ isLoading }),
-}))
+export const useUserStore = create<UserStore>()(
+  persist(
+    (set) => ({
+      user: null,
+      isLoading: false,
+      setUser: (user) => set({ user }),
+      clearUser: () => set({ user: null }),
+      setLoading: (isLoading) => set({ isLoading }),
+    }),
+    {
+      name: 'comicscout-user-session',
+    }
+  )
+)


### PR DESCRIPTION
Implements session persistence for user authentication state using Zustand's persist middleware.

## Changes
- Import persist middleware from zustand/middleware
- Wrap userStore with persist middleware
- Configure persistence with 'comicscout-user-session' storage name
- User authentication state now persists across page refreshes

Fixes #105

Generated with [Claude Code](https://claude.ai/code)