### PR TITLE
fix: resolve Supabase and Vite type declaration errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "gen:types": "supabase gen types typescript --linked > src/lib/database.types.ts"
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.56.1",
@@ -33,6 +34,7 @@
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-react-refresh": "^0.4.3",
     "postcss": "^8.4.27",
+    "supabase": "^1.200.3",
     "tailwindcss": "^3.3.3",
     "typescript": "^5.0.2",
     "vite": "^4.4.5"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import Footer from './components/layout/Footer'
 import LoadingSpinner from './components/ui/LoadingSpinner'
 import { useUserStore } from './store/userStore'
 import { supabase } from './lib/supabaseClient'
+import type { AuthChangeEvent, Session } from '@supabase/supabase-js'
 
 // Lazy load pages for better performance
 const HomePage = lazy(() => import('./pages/HomePage'))
@@ -42,7 +43,7 @@ function App() {
 
     // Listen for auth changes
     const { data: { subscription } } = supabase.auth.onAuthStateChange(
-      async (event, session) => {
+      async (event: AuthChangeEvent, session: Session | null) => {
         if (event === 'SIGNED_OUT' || !session) {
           setUser(null)
         } else if (event === 'SIGNED_IN' && session?.user) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
     "skipLibCheck": true,
     "noUnusedLocals": false,
     "noUnusedParameters": false,
+    "types": ["vite/client"],
 
     /* Bundler mode */
     "moduleResolution": "bundler",


### PR DESCRIPTION
Resolves #109

This PR fixes the critical TypeScript and Vite-related build errors causing Vercel deployment failures:

## Changes
- Add `vite/client` to tsconfig types array to support import.meta.env
- Add Supabase CLI as dev dependency for type generation
- Add gen:types script to generate database types from schema
- Fix implicit 'any' types in onAuthStateChange callback
- Import AuthChangeEvent and Session types from @supabase/supabase-js

## Errors Fixed
- TS2307: Cannot find module '@supabase/supabase-js'
- TS2339: Property 'env' does not exist on type 'ImportMeta'
- TS7006: Parameter 'event' and 'session' implicitly has 'any' type

Generated with [Claude Code](https://claude.ai/code)