### PR TITLE
fix: Add missing 'createdAt' property to CollectionComic type

### DIFF
--- a/src/pages/CollectionPage.tsx
+++ b/src/pages/CollectionPage.tsx
@@ -60,7 +60,7 @@ const CollectionPage: React.FC = () => {
     purchasePriceValue: collectionComic.purchasePrice || 0,
     purchaseDate: collectionComic.purchaseDate ? new Date(collectionComic.purchaseDate).toLocaleDateString() : 'N/A',
     purchaseDateValue: collectionComic.purchaseDate ? new Date(collectionComic.purchaseDate) : null,
-    addedDate: collectionComic.createdAt ? new Date(collectionComic.createdAt) : new Date(),
+    addedDate: collectionComic.addedDate ? new Date(collectionComic.addedDate) : new Date(),
   })) || []
 
   // Create filtered and sorted comics using useMemo


### PR DESCRIPTION
Fixes critical TypeScript error that was causing Vercel deployment to fail.

- Changed `collectionComic.createdAt` to `collectionComic.addedDate` in CollectionPage.tsx
- The CollectionComic interface has 'addedDate' property, not 'createdAt'
- Supabase `created_at` field is correctly mapped to `addedDate` in collectionService

Fixes #115

Generated with [Claude Code](https://claude.ai/code)