### PR TITLE
fix: Update Supabase queries to use camelCase column names

### DIFF
--- a/src/services/alertService.ts
+++ b/src/services/alertService.ts
@@ -4,16 +4,16 @@ import type { UserAlert, AlertType } from '@/lib/types'
 // Interface for the alerts table in Supabase
 export interface SupabaseAlert {
   id: string
-  user_id: string
-  comic_id?: string
+  userId: string
+  comicId?: string
   name: string
-  alert_type: AlertType
-  threshold_price?: number
-  price_direction?: 'above' | 'below'
-  is_active: boolean
-  created_at: string
-  last_triggered?: string
-  trigger_count: number
+  alertType: AlertType
+  thresholdPrice?: number
+  priceDirection?: 'above' | 'below'
+  isActive: boolean
+  createdAt: string
+  lastTriggered?: string
+  triggerCount: number
   description?: string
 }
 
@@ -21,17 +21,17 @@ export interface SupabaseAlert {
 const transformSupabaseAlert = (supabaseAlert: SupabaseAlert): UserAlert => {
   const userAlert: UserAlert = {
     id: supabaseAlert.id,
-    userId: supabaseAlert.user_id,
-    comicId: supabaseAlert.comic_id,
-    type: supabaseAlert.alert_type,
+    userId: supabaseAlert.userId,
+    comicId: supabaseAlert.comicId,
+    type: supabaseAlert.alertType,
     criteria: {
-      priceThreshold: supabaseAlert.threshold_price,
-      priceDirection: supabaseAlert.price_direction,
+      priceThreshold: supabaseAlert.thresholdPrice,
+      priceDirection: supabaseAlert.priceDirection,
     },
-    isActive: supabaseAlert.is_active,
-    createdDate: supabaseAlert.created_at,
-    lastTriggered: supabaseAlert.last_triggered,
-    triggerCount: supabaseAlert.trigger_count,
+    isActive: supabaseAlert.isActive,
+    createdDate: supabaseAlert.createdAt,
+    lastTriggered: supabaseAlert.lastTriggered,
+    triggerCount: supabaseAlert.triggerCount,
     name: supabaseAlert.name,
     description: supabaseAlert.description,
   }
@@ -47,8 +47,8 @@ export const fetchAlerts = async (userId: string): Promise<UserAlert[]> => {
   const { data, error } = await supabase
     .from('alerts')
     .select('*')
-    .eq('user_id', userId)
-    .order('created_at', { ascending: false })
+    .eq('userId', userId)
+    .order('createdAt', { ascending: false })
 
   if (error) {
     throw new Error(`Failed to fetch alerts: ${error.message}`)
@@ -73,15 +73,15 @@ export interface CreateAlertData {
 
 export const createAlert = async (alertData: CreateAlertData): Promise<UserAlert> => {
   const supabaseAlertData = {
-    user_id: alertData.userId,
-    comic_id: alertData.comicId,
+    userId: alertData.userId,
+    comicId: alertData.comicId,
     name: alertData.name,
-    alert_type: alertData.alertType,
-    threshold_price: alertData.thresholdPrice,
-    price_direction: alertData.priceDirection,
+    alertType: alertData.alertType,
+    thresholdPrice: alertData.thresholdPrice,
+    priceDirection: alertData.priceDirection,
     description: alertData.description,
-    is_active: true,
-    trigger_count: 0,
+    isActive: true,
+    triggerCount: 0,
   }
 
   const { data, error } = await supabase
@@ -104,7 +104,7 @@ export const createAlert = async (alertData: CreateAlertData): Promise<UserAlert
 export const updateAlertStatus = async (alertId: string, isActive: boolean): Promise<UserAlert> => {
   const { data, error } = await supabase
     .from('alerts')
-    .update({ is_active: isActive })
+    .update({ isActive: isActive })
     .eq('id', alertId)
     .select()
     .single()

--- a/src/services/collectionService.ts
+++ b/src/services/collectionService.ts
@@ -7,19 +7,19 @@ export interface SupabaseComic {
   title: string
   issue: string
   publisher: string
-  cover_image: string
-  market_value: number
+  coverImage: string
+  marketValue: number
   condition: string
-  purchase_price?: number
-  purchase_date?: string
-  purchase_location?: string
+  purchasePrice?: number
+  purchaseDate?: string
+  purchaseLocation?: string
   notes?: string
-  publication_year?: number
+  publicationYear?: number
   format?: string
-  is_key_issue?: boolean
-  key_issue_reason?: string
-  created_at: string
-  user_id: string
+  isKeyIssue?: boolean
+  keyIssueReason?: string
+  createdAt: string
+  userId: string
 }
 
 // Transform Supabase data to match our frontend types
@@ -31,18 +31,18 @@ const transformSupabaseComic = (supabaseComic: SupabaseComic): CollectionComic =
     issue: supabaseComic.issue,
     issueNumber: parseInt(supabaseComic.issue.replace('#', '')) || 0,
     publisher: supabaseComic.publisher,
-    publishDate: supabaseComic.publication_year ? 
+    publishDate: supabaseComic.publicationYear ? 
       new Date(supabaseComic.publication_year, 0, 1).toISOString() : 
       new Date().toISOString(),
-    coverImage: supabaseComic.cover_image,
+    coverImage: supabaseComic.coverImage,
     creators: [], // This should be populated from your schema
     format: (supabaseComic.format as any) || 'single-issue',
     isVariant: false,
-    isKeyIssue: supabaseComic.is_key_issue || false,
-    keyIssueReason: supabaseComic.key_issue_reason,
+    isKeyIssue: supabaseComic.isKeyIssue || false,
+    keyIssueReason: supabaseComic.keyIssueReason,
     prices: [],
-    marketValue: supabaseComic.market_value,
-    lastUpdated: supabaseComic.created_at
+    marketValue: supabaseComic.marketValue,
+    lastUpdated: supabaseComic.createdAt
   }
 
   // Create a CollectionComic object
@@ -50,11 +50,11 @@ const transformSupabaseComic = (supabaseComic: SupabaseComic): CollectionComic =
     comicId: supabaseComic.id,
     comic: comic,
     condition: supabaseComic.condition as any, // Type assertion - adjust based on your schema
-    purchasePrice: supabaseComic.purchase_price,
-    purchaseDate: supabaseComic.purchase_date,
-    purchaseLocation: supabaseComic.purchase_location,
+    purchasePrice: supabaseComic.purchasePrice,
+    purchaseDate: supabaseComic.purchaseDate,
+    purchaseLocation: supabaseComic.purchaseLocation,
     notes: supabaseComic.notes,
-    addedDate: supabaseComic.created_at
+    addedDate: supabaseComic.createdAt
   }
 
   return collectionComic
@@ -83,12 +83,12 @@ export const fetchUserCollection = async (
     throw new Error('User ID is required')
   }
 
-  const { filters = {}, sortOrder = 'created_at', page = 1, itemsPerPage = 12 } = options
+  const { filters = {}, sortOrder = 'createdAt', page = 1, itemsPerPage = 12 } = options
 
   let query = supabase
     .from('comics')
     .select('*')
-    .eq('user_id', userId)
+    .eq('userId', userId)
 
   // Apply search filter
   if (filters.searchTerm && filters.searchTerm.trim()) {
@@ -108,25 +108,25 @@ export const fetchUserCollection = async (
 
   // Apply price range filter
   if (filters.priceRange?.min !== undefined) {
-    query = query.gte('market_value', filters.priceRange.min)
+    query = query.gte('marketValue', filters.priceRange.min)
   }
   if (filters.priceRange?.max !== undefined) {
-    query = query.lte('market_value', filters.priceRange.max)
+    query = query.lte('marketValue', filters.priceRange.max)
   }
 
   // Apply year range filter (assuming purchase_date is available)
   if (filters.yearRange?.min !== undefined) {
     const minYear = `${filters.yearRange.min}-01-01`
-    query = query.gte('purchase_date', minYear)
+    query = query.gte('purchaseDate', minYear)
   }
   if (filters.yearRange?.max !== undefined) {
     const maxYear = `${filters.yearRange.max}-12-31`
-    query = query.lte('purchase_date', maxYear)
+    query = query.lte('purchaseDate', maxYear)
   }
 
   // Apply sorting
   let ascending = false
-  let orderColumn = 'created_at'
+  let orderColumn = 'createdAt'
   
   switch (sortOrder) {
     case 'title':
@@ -139,24 +139,24 @@ export const fetchUserCollection = async (
       ascending = true
       break
     case 'market-value':
-      orderColumn = 'market_value'
+      orderColumn = 'marketValue'
       ascending = false // Highest first
       break
     case 'purchase-price':
-      orderColumn = 'purchase_price'
+      orderColumn = 'purchasePrice'
       ascending = false // Highest first
       break
     case 'added-date':
-      orderColumn = 'created_at'
+      orderColumn = 'createdAt'
       ascending = false // Most recent first
       break
     case 'publish-date':
     case 'purchase-date':
-      orderColumn = 'purchase_date'
+      orderColumn = 'purchaseDate'
       ascending = false // Most recent first
       break
     default:
-      orderColumn = 'created_at'
+      orderColumn = 'createdAt'
       ascending = false
   }
 
@@ -192,7 +192,7 @@ export const getCollectionCount = async (
   let query = supabase
     .from('comics')
     .select('*', { count: 'exact', head: true })
-    .eq('user_id', userId)
+    .eq('userId', userId)
 
   // Apply the same filters as fetchUserCollection but only for counting
   if (filters.searchTerm && filters.searchTerm.trim()) {
@@ -209,19 +209,19 @@ export const getCollectionCount = async (
   }
 
   if (filters.priceRange?.min !== undefined) {
-    query = query.gte('market_value', filters.priceRange.min)
+    query = query.gte('marketValue', filters.priceRange.min)
   }
   if (filters.priceRange?.max !== undefined) {
-    query = query.lte('market_value', filters.priceRange.max)
+    query = query.lte('marketValue', filters.priceRange.max)
   }
 
   if (filters.yearRange?.min !== undefined) {
     const minYear = `${filters.yearRange.min}-01-01`
-    query = query.gte('purchase_date', minYear)
+    query = query.gte('purchaseDate', minYear)
   }
   if (filters.yearRange?.max !== undefined) {
     const maxYear = `${filters.yearRange.max}-12-31`
-    query = query.lte('purchase_date', maxYear)
+    query = query.lte('purchaseDate', maxYear)
   }
 
   const { count, error } = await query
@@ -296,22 +296,22 @@ export const addComic = async (userId: string, comicData: AddComicData): Promise
 
   // Map the form data to Supabase schema
   const supabaseData = {
-    user_id: userId,
+    userId: userId,
     title: comicData.title,
     issue: comicData.issueNumber,
     publisher: comicData.publisher,
-    publication_year: comicData.publicationYear,
+    publicationYear: comicData.publicationYear,
     condition: comicData.condition,
     format: comicData.format,
-    market_value: comicData.estimatedValue || 0,
-    purchase_price: comicData.purchasePrice,
-    purchase_date: comicData.purchaseDate,
-    purchase_location: comicData.purchaseLocation,
-    cover_image: comicData.coverImageUrl || '',
+    marketValue: comicData.estimatedValue || 0,
+    purchasePrice: comicData.purchasePrice,
+    purchaseDate: comicData.purchaseDate,
+    purchaseLocation: comicData.purchaseLocation,
+    coverImage: comicData.coverImageUrl || '',
     notes: comicData.notes,
-    is_key_issue: comicData.isKeyIssue,
-    key_issue_reason: comicData.keyIssueReason,
-    created_at: comicData.addedDate
+    isKeyIssue: comicData.isKeyIssue,
+    keyIssueReason: comicData.keyIssueReason,
+    createdAt: comicData.addedDate
   }
 
   const { data, error } = await supabase
@@ -343,17 +343,17 @@ export const updateComic = async (comicId: string, updatedData: Partial<AddComic
   if (updatedData.title) supabaseData.title = updatedData.title
   if (updatedData.issueNumber) supabaseData.issue = updatedData.issueNumber
   if (updatedData.publisher) supabaseData.publisher = updatedData.publisher
-  if (updatedData.publicationYear) supabaseData.publication_year = updatedData.publicationYear
+  if (updatedData.publicationYear) supabaseData.publicationYear = updatedData.publicationYear
   if (updatedData.condition) supabaseData.condition = updatedData.condition
   if (updatedData.format) supabaseData.format = updatedData.format
-  if (updatedData.estimatedValue !== undefined) supabaseData.market_value = updatedData.estimatedValue || 0
-  if (updatedData.purchasePrice !== undefined) supabaseData.purchase_price = updatedData.purchasePrice
-  if (updatedData.purchaseDate !== undefined) supabaseData.purchase_date = updatedData.purchaseDate
-  if (updatedData.purchaseLocation !== undefined) supabaseData.purchase_location = updatedData.purchaseLocation
-  if (updatedData.coverImageUrl !== undefined) supabaseData.cover_image = updatedData.coverImageUrl || ''
+  if (updatedData.estimatedValue !== undefined) supabaseData.marketValue = updatedData.estimatedValue || 0
+  if (updatedData.purchasePrice !== undefined) supabaseData.purchasePrice = updatedData.purchasePrice
+  if (updatedData.purchaseDate !== undefined) supabaseData.purchaseDate = updatedData.purchaseDate
+  if (updatedData.purchaseLocation !== undefined) supabaseData.purchaseLocation = updatedData.purchaseLocation
+  if (updatedData.coverImageUrl !== undefined) supabaseData.coverImage = updatedData.coverImageUrl || ''
   if (updatedData.notes !== undefined) supabaseData.notes = updatedData.notes
-  if (updatedData.isKeyIssue !== undefined) supabaseData.is_key_issue = updatedData.isKeyIssue
-  if (updatedData.keyIssueReason !== undefined) supabaseData.key_issue_reason = updatedData.keyIssueReason
+  if (updatedData.isKeyIssue !== undefined) supabaseData.isKeyIssue = updatedData.isKeyIssue
+  if (updatedData.keyIssueReason !== undefined) supabaseData.keyIssueReason = updatedData.keyIssueReason
 
   const { data, error } = await supabase
     .from('comics')

--- a/src/services/homeService.ts
+++ b/src/services/homeService.ts
@@ -28,22 +28,22 @@ export const fetchUserStats = async (userId: string): Promise<UserStats> => {
   // Get total comics count and collection value
   const { data: comics, error: comicsError } = await supabase
     .from('comics')
-    .select('market_value')
-    .eq('user_id', userId)
+    .select('marketValue')
+    .eq('userId', userId)
 
   if (comicsError) {
     throw new Error(`Failed to fetch user stats: ${comicsError.message}`)
   }
 
   const totalComics = comics?.length || 0
-  const collectionValue = comics?.reduce((sum, comic) => sum + (comic.market_value || 0), 0) || 0
+  const collectionValue = comics?.reduce((sum, comic) => sum + (comic.marketValue || 0), 0) || 0
 
   // Get active alerts count (assuming alerts table exists)
   const { count: alertsCount, error: alertsError } = await supabase
     .from('alerts')
     .select('*', { count: 'exact', head: true })
-    .eq('user_id', userId)
-    .eq('is_active', true)
+    .eq('userId', userId)
+    .eq('isActive', true)
 
   if (alertsError) {
     console.warn('Failed to fetch alerts count:', alertsError.message)
@@ -56,8 +56,8 @@ export const fetchUserStats = async (userId: string): Promise<UserStats> => {
   const { count: recentCount, error: recentError } = await supabase
     .from('comics')
     .select('*', { count: 'exact', head: true })
-    .eq('user_id', userId)
-    .gte('created_at', sevenDaysAgo.toISOString())
+    .eq('userId', userId)
+    .gte('createdAt', sevenDaysAgo.toISOString())
 
   if (recentError) {
     console.warn('Failed to fetch recent additions count:', recentError.message)
@@ -75,8 +75,8 @@ export const fetchUserStats = async (userId: string): Promise<UserStats> => {
 export const fetchHotComics = async (): Promise<HotComic[]> => {
   const { data: comics, error } = await supabase
     .from('comics')
-    .select('id, title, issue, publisher, cover_image, market_value, created_at')
-    .order('created_at', { ascending: false })
+    .select('id, title, issue, publisher, coverImage, marketValue, createdAt')
+    .order('createdAt', { ascending: false })
     .limit(5)
 
   if (error) {
@@ -93,8 +93,8 @@ export const fetchHotComics = async (): Promise<HotComic[]> => {
     title: comic.title,
     issue: comic.issue,
     publisher: comic.publisher,
-    coverImage: comic.cover_image || `https://via.placeholder.com/200x300/D62828/FDF6E3?text=${encodeURIComponent(comic.title)}`,
-    value: `£${comic.market_value?.toLocaleString() || '0'}`,
+    coverImage: comic.coverImage || `https://via.placeholder.com/200x300/D62828/FDF6E3?text=${encodeURIComponent(comic.title)}`,
+    value: `£${comic.marketValue?.toLocaleString() || '0'}`,
     trend: index < 3 ? 'up' : 'neutral' as const, // Mock trend for now
     change: index < 3 ? `+${5 + index * 3}%` : '0%'
   }))
@@ -104,8 +104,8 @@ export const fetchHotComics = async (): Promise<HotComic[]> => {
 export const fetchRecentNews = async (): Promise<NewsArticle[]> => {
   const { data: news, error } = await supabase
     .from('news')
-    .select('id, title, excerpt, author, publish_date, category, featured_image')
-    .order('publish_date', { ascending: false })
+    .select('id, title, excerpt, author, publishDate, category, featuredImage')
+    .order('publishDate', { ascending: false })
     .limit(3)
 
   if (error) {
@@ -123,9 +123,9 @@ export const fetchRecentNews = async (): Promise<NewsArticle[]> => {
     excerpt: article.excerpt,
     content: '', // Not needed for preview
     author: article.author,
-    publishDate: article.publish_date,
+    publishDate: article.publishDate,
     category: article.category as any,
     tags: [],
-    featuredImage: article.featured_image
+    featuredImage: article.featuredImage
   }))
 }


### PR DESCRIPTION
Fixes #137

This PR resolves 400 Bad Request errors by updating all Supabase client queries to use camelCase column names instead of snake_case.

## Changes:
- Updated collectionService.ts column references
- Updated homeService.ts column references
- Updated alertService.ts column references
- Fixed all select(), order(), eq(), and filter statements

## Testing:
The application should now load and display data from the comics and news tables without 400 errors.

Generated with [Claude Code](https://claude.ai/code)