### PR TITLE
fix: Correct typo in collectionService

### DIFF
--- a/src/services/collectionService.ts
+++ b/src/services/collectionService.ts
@@ -32,7 +32,7 @@ const transformSupabaseComic = (supabaseComic: SupabaseComic): CollectionComic =
     issueNumber: parseInt(supabaseComic.issue.replace('#', '')) || 0,
     publisher: supabaseComic.publisher,
     publishDate: supabaseComic.publicationYear ? 
-      new Date(supabaseComic.publication_year, 0, 1).toISOString() : 
+      new Date(supabaseComic.publicationYear, 0, 1).toISOString() : 
       new Date().toISOString(),
     coverImage: supabaseComic.coverImage,
     creators: [], // This should be populated from your schema


### PR DESCRIPTION
Fixes TypeScript build error TS2551 by correcting property name typo

- Changed `publication_year` to `publicationYear` in collectionService.ts
- Matches the correct camelCase property defined in SupabaseComic interface

Closes #139

Generated with [Claude Code](https://claude.ai/code)