### PR TITLE
fix: correct parameter name for Supabase auth confirmation

### DIFF
--- a/src/pages/AuthConfirmPage.tsx
+++ b/src/pages/AuthConfirmPage.tsx
@@ -17,7 +17,7 @@ const AuthConfirmPage: React.FC = () => {
   useEffect(() => {
     const confirmUser = async () => {
       try {
-        const token = searchParams.get('token')
+        const token = searchParams.get('token_hash')
         const type = searchParams.get('type')
 
         if (!token) {


### PR DESCRIPTION
Fixes #145

This PR fixes the 404 error when users click email verification links from Supabase auth.

## Changes
- Fixed parameter name mismatch in `AuthConfirmPage.tsx`
- Changed from looking for `token` to `token_hash` parameter
- Matches Supabase's email verification URL format: `/auth/confirm?token_hash=...&type=signup`

Generated with [Claude Code](https://claude.ai/code)