### PR TITLE
Fix 404 errors on auth routes by adding vercel.json for SPA routing

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "rewrites": [
+    {
+      "source": "/(.*)",
+      "destination": "/index.html"
+    }
+  ]
+}


### PR DESCRIPTION
This PR fixes 404 errors on `/auth` routes by adding proper Vercel configuration for Single Page Application routing.

## Problem
- Email verification URLs from Supabase were returning 404 errors
- Routes like `/auth/confirm` worked locally but failed in production
- Vercel didn't know to serve `index.html` for client-side routes

## Solution
- Added `vercel.json` with SPA rewrite configuration
- All routes now redirect to `index.html` to let React Router handle navigation
- React Router configuration was already correct with proper auth routes

## Files Changed
- `vercel.json` (new) - SPA routing configuration

Closes #147

Generated with [Claude Code](https://claude.ai/code)