### PR TITLE
feat: Implement toast notifications for all CRUD actions

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.20.0",
     "recharts": "^2.10.0",
+    "sonner": "^1.4.41",
     "zustand": "^4.4.7"
   },
   "devDependencies": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import MainNavbar from './components/layout/MainNavbar'
 import Footer from './components/layout/Footer'
 import LoadingSpinner from './components/ui/LoadingSpinner'
 import ToastContainer from './components/ui/ToastContainer'
+import { Toaster } from 'sonner'
 import { useUserStore } from './store/userStore'
 import { supabase } from './lib/supabaseClient'
 import type { AuthChangeEvent, Session } from '@supabase/supabase-js'
@@ -102,6 +103,9 @@ function App() {
       
       {/* Toast Container */}
       <ToastContainer />
+      
+      {/* Sonner Toast Provider */}
+      <Toaster />
     </div>
   )
 }

--- a/src/components/features/AddComicForm.tsx
+++ b/src/components/features/AddComicForm.tsx
@@ -1,11 +1,11 @@
 import React, { useState } from 'react'
 import { X, Plus, Book, Upload, Image as ImageIcon } from 'lucide-react'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { toast } from 'sonner'
 import type { ComicCondition, ComicFormat } from '@/lib/types'
 import { uploadComicImage } from '@/services/storageService'
 import { addComic, type AddComicData } from '@/services/collectionService'
 import { useUserStore } from '@/store/userStore'
-import { toast } from '@/store/toastStore'
 
 interface AddComicFormProps {
   isOpen: boolean
@@ -97,7 +97,7 @@ const AddComicForm: React.FC<AddComicFormProps> = ({ isOpen, onClose }) => {
       queryClient.invalidateQueries({ queryKey: ['collection-count', user?.email] })
       
       // Show success notification
-      toast.success('Comic Added Successfully', 'Your comic has been added to your collection.')
+      toast.success('Comic Added', { description: 'The new comic has been saved to your collection.' })
       
       // Reset form and close modal
       resetForm()
@@ -105,7 +105,8 @@ const AddComicForm: React.FC<AddComicFormProps> = ({ isOpen, onClose }) => {
     },
     onError: (error) => {
       console.error('Failed to save comic:', error)
-      // Error handling will be done in the submit handler
+      // Show error notification
+      toast.error('Save Failed', { description: 'The comic could not be saved. Please try again.' })
     }
   })
 

--- a/src/components/features/EditComicForm.tsx
+++ b/src/components/features/EditComicForm.tsx
@@ -1,11 +1,11 @@
 import React, { useState, useEffect } from 'react'
 import { X, Plus, Book, Upload, Image as ImageIcon, Save } from 'lucide-react'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { toast } from 'sonner'
 import type { ComicCondition, ComicFormat, CollectionComic } from '@/lib/types'
 import { uploadComicImage } from '@/services/storageService'
 import { updateComic, type AddComicData } from '@/services/collectionService'
 import { useUserStore } from '@/store/userStore'
-import { toast } from '@/store/toastStore'
 
 interface EditComicFormProps {
   isOpen: boolean
@@ -125,14 +125,15 @@ const EditComicForm: React.FC<EditComicFormProps> = ({ isOpen, onClose, comic })
       queryClient.invalidateQueries({ queryKey: ['comic', comic.comicId] })
       
       // Show success notification
-      toast.success('Comic Updated Successfully', 'Your comic details have been updated.')
+      toast.success('Changes Saved', { description: 'Your updates to the comic have been saved.' })
       
       // Close modal
       onClose()
     },
     onError: (error) => {
       console.error('Failed to update comic:', error)
-      // Error handling will be done in the submit handler
+      // Show error notification
+      toast.error('Save Failed', { description: 'Your changes could not be saved. Please try again.' })
     }
   })
 


### PR DESCRIPTION
Fixes #153

## Summary
Implemented toast notifications for Add Comic and Edit Comic actions using the sonner library as requested.

## Changes
- Added sonner library dependency
- Added Toaster component to App.tsx
- Updated AddComicForm with proper success/error toasts
- Updated EditComicForm with proper success/error toasts
- Replaced custom toast system with sonner in both forms

## Test Plan
- [ ] Verify success toast appears when adding a new comic
- [ ] Verify error toast appears when comic add fails
- [ ] Verify success toast appears when editing a comic
- [ ] Verify error toast appears when comic edit fails
- [ ] Confirm toasts display at bottom of screen with proper styling

Generated with [Claude Code](https://claude.ai/code)