### PR TITLE
fix: update favicon references to use existing files

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,12 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/comic-icon.svg" />
+    <!-- Favicon -->
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="icon" type="image/png" sizes="96x96" href="/favicon-96x96.png" />
+    <link rel="shortcut icon" href="/favicon.ico" />
+    <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
+    <link rel="manifest" href="/site.webmanifest" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>ComicScoutUK - Your Ultimate Comic Collection Manager</title>
     


### PR DESCRIPTION
Fixes the favicon implementation by updating index.html to reference existing files instead of the non-existent comic-icon.svg.

Changes:
- Replace non-existent /comic-icon.svg with /favicon.svg
- Add comprehensive favicon support including PNG fallbacks
- Add apple-touch-icon and web manifest references
- All href paths now match files in public directory

Fixes #175

Generated with [Claude Code](https://claude.ai/code)