### PR TITLE
fix: Correct column name in comic search query

### DIFF
--- a/src/services/searchService.ts
+++ b/src/services/searchService.ts
@@ -18,7 +18,7 @@ const transformSearchResult = (data: any): SearchResultComic => {
   return {
     id: data.id,
     title: data.title,
-    issueNumber: data.issue,
+    issueNumber: data.issueNumber,
     publisher: data.publisher,
     coverImageUrl: data.coverImage,
     marketValue: data.marketValue || 0,
@@ -41,7 +41,7 @@ export const searchPublicComics = async (searchTerm: string): Promise<SearchResu
     .select(`
       id,
       title,
-      issue,
+      issueNumber,
       publisher,
       coverImage,
       marketValue,


### PR DESCRIPTION
Fixes #179

This PR resolves the runtime error in the global comic search feature where the query was referencing a non-existent column name.

## Changes
- Changed Supabase query in `searchPublicComics` from selecting `issue` to `issueNumber`
- Updated transform function to use `data.issueNumber` instead of `data.issue`

## Testing
The fix ensures that the global comic search functionality will work without the "column comics.issue does not exist" error.

Generated with [Claude Code](https://claude.ai/code)