### PR TITLE
fix: Correct database column names in searchPublicComics query

### DIFF
--- a/src/services/searchService.ts
+++ b/src/services/searchService.ts
@@ -20,11 +20,11 @@ const transformSearchResult = (data: any): SearchResultComic => {
     title: data.title,
     issueNumber: data.issue,
     publisher: data.publisher,
-    coverImageUrl: data.coverImageUrl,
-    marketValue: data.marketValue || 0,
+    coverImageUrl: data.cover_image,
+    marketValue: data.market_value || 0,
     publicationYear: data.publication_year,
-    isKeyIssue: data.isKeyIssue || false,
-    keyIssueReason: data.keyIssueReason
+    isKeyIssue: data.is_key_issue || false,
+    keyIssueReason: data.key_issue_reason
   }
 }
 
@@ -43,11 +43,11 @@ export const searchPublicComics = async (searchTerm: string): Promise<SearchResu
       title,
       issue,
       publisher,
-      coverImageUrl,
-      marketValue,
+      cover_image,
+      market_value,
       publication_year,
-      isKeyIssue,
-      keyIssueReason
+      is_key_issue,
+      key_issue_reason
     `)
     .ilike('title', `%${trimmedSearch}%`)
     .order('title', { ascending: true })


### PR DESCRIPTION
Fixes the runtime error in the global comic search feature by correcting database column name references.

## Changes
- Fix coverImageUrl → cover_image
- Fix marketValue → market_value
- Fix isKeyIssue → is_key_issue
- Fix keyIssueReason → key_issue_reason

The searchPublicComics function was referencing camelCase column names that don't exist in the database. Updated to use the correct snake_case column names as defined in the database schema.

Fixes #195

Generated with [Claude Code](https://claude.ai/code)