### PR TITLE
Remove publication_year references from SQL queries

### DIFF
--- a/src/components/features/AddComicForm.tsx
+++ b/src/components/features/AddComicForm.tsx
@@ -66,7 +66,6 @@ const AddComicForm: React.FC<AddComicFormProps> = ({ isOpen, onClose }) => {
     issueNumber: '',
     publisher: '',
     customPublisher: '',
-    publicationYear: '',
     condition: 'near-mint' as ComicCondition,
     format: 'single-issue' as ComicFormat,
     estimatedValue: '',
@@ -154,7 +153,6 @@ const AddComicForm: React.FC<AddComicFormProps> = ({ isOpen, onClose }) => {
       issueNumber: '',
       publisher: '',
       customPublisher: '',
-      publicationYear: '',
       condition: 'near-mint' as ComicCondition,
       format: 'single-issue' as ComicFormat,
       estimatedValue: '',
@@ -191,14 +189,6 @@ const AddComicForm: React.FC<AddComicFormProps> = ({ isOpen, onClose }) => {
       newErrors.customPublisher = 'Custom publisher name is required'
     }
 
-    if (!formData.publicationYear.trim()) {
-      newErrors.publicationYear = 'Publication year is required'
-    } else {
-      const year = parseInt(formData.publicationYear)
-      if (isNaN(year) || year < 1800 || year > new Date().getFullYear() + 1) {
-        newErrors.publicationYear = 'Please enter a valid year (1800 or later)'
-      }
-    }
 
     if (formData.estimatedValue && isNaN(parseFloat(formData.estimatedValue))) {
       newErrors.estimatedValue = 'Please enter a valid amount'
@@ -246,7 +236,6 @@ const AddComicForm: React.FC<AddComicFormProps> = ({ isOpen, onClose }) => {
         title: formData.title.trim(),
         issueNumber: formData.issueNumber.trim(),
         publisher: formData.publisher === 'Other' ? formData.customPublisher.trim() : formData.publisher,
-        publicationYear: parseInt(formData.publicationYear),
         condition: formData.condition,
         format: formData.format,
         estimatedValue: formData.estimatedValue ? parseFloat(formData.estimatedValue) : null,
@@ -392,41 +381,20 @@ const AddComicForm: React.FC<AddComicFormProps> = ({ isOpen, onClose }) => {
               </div>
             )}
 
-            {/* Publication Year and Format */}
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-              <div>
-                <label className="block font-persona-aura font-semibold text-ink-black mb-2">
-                  Publication Year *
-                </label>
-                <input
-                  type="number"
-                  value={formData.publicationYear}
-                  onChange={(e) => handleChange('publicationYear', e.target.value)}
-                  className={`w-full p-3 border-2 comic-border font-persona-aura focus:outline-none focus:ring-2 focus:ring-stan-lee-blue ${
-                    errors.publicationYear ? 'border-red-500' : 'border-ink-black'
-                  }`}
-                  placeholder="e.g., 2024"
-                  min="1800"
-                  max={new Date().getFullYear() + 1}
-                  required
-                />
-                {errors.publicationYear && <p className="mt-1 text-sm text-red-600 font-persona-aura">{errors.publicationYear}</p>}
-              </div>
-
-              <div>
-                <label className="block font-persona-aura font-semibold text-ink-black mb-2">
-                  Format
-                </label>
-                <select
-                  value={formData.format}
-                  onChange={(e) => handleChange('format', e.target.value)}
-                  className="w-full p-3 border-2 border-ink-black comic-border font-persona-aura focus:outline-none focus:ring-2 focus:ring-stan-lee-blue"
-                >
-                  {formatOptions.map(format => (
-                    <option key={format.value} value={format.value}>{format.label}</option>
-                  ))}
-                </select>
-              </div>
+            {/* Format */}
+            <div>
+              <label className="block font-persona-aura font-semibold text-ink-black mb-2">
+                Format
+              </label>
+              <select
+                value={formData.format}
+                onChange={(e) => handleChange('format', e.target.value)}
+                className="w-full p-3 border-2 border-ink-black comic-border font-persona-aura focus:outline-none focus:ring-2 focus:ring-stan-lee-blue"
+              >
+                {formatOptions.map(format => (
+                  <option key={format.value} value={format.value}>{format.label}</option>
+                ))}
+              </select>
             </div>
           </div>
 

--- a/src/components/features/ComicSearchModal.tsx
+++ b/src/components/features/ComicSearchModal.tsx
@@ -266,7 +266,6 @@ const ComicSearchModal: React.FC<ComicSearchModalProps> = ({ isOpen, onClose }) 
                             </h4>
                             <p className="font-persona-aura text-gray-600 mb-1">
                               {comic.publisher}
-                              {comic.publication_year && ` • ${comic.publication_year}`}
                             </p>
                             {comic.is_key_issue && (
                               <p className="font-persona-aura text-kirby-red font-semibold mb-1">
@@ -315,7 +314,6 @@ const ComicSearchModal: React.FC<ComicSearchModalProps> = ({ isOpen, onClose }) 
                     </h4>
                     <p className="font-persona-aura text-gray-600 mb-1">
                       {selectedComic?.publisher}
-                      {selectedComic?.publication_year && ` • ${selectedComic.publication_year}`}
                     </p>
                     <p className="font-persona-aura text-stan-lee-blue font-semibold">
                       Market Value: £{selectedComic?.market_value.toFixed(2)}

--- a/src/components/features/EditComicForm.tsx
+++ b/src/components/features/EditComicForm.tsx
@@ -67,7 +67,6 @@ const EditComicForm: React.FC<EditComicFormProps> = ({ isOpen, onClose, comic })
     issueNumber: '',
     publisher: '',
     customPublisher: '',
-    publicationYear: '',
     condition: 'near-mint' as ComicCondition,
     format: 'single-issue' as ComicFormat,
     estimatedValue: '',
@@ -87,7 +86,6 @@ const EditComicForm: React.FC<EditComicFormProps> = ({ isOpen, onClose, comic })
   // Populate form with comic data when modal opens or comic changes
   useEffect(() => {
     if (isOpen && comic) {
-      const publicationYear = comic.comic.publishDate ? new Date(comic.comic.publishDate).getFullYear().toString() : ''
       const isCustomPublisher = !publisherOptions.slice(0, -1).includes(comic.comic.publisher)
       
       setFormData({
@@ -95,7 +93,6 @@ const EditComicForm: React.FC<EditComicFormProps> = ({ isOpen, onClose, comic })
         issueNumber: comic.comic.issue || '',
         publisher: isCustomPublisher ? 'Other' : comic.comic.publisher || '',
         customPublisher: isCustomPublisher ? comic.comic.publisher || '' : '',
-        publicationYear,
         condition: comic.condition || 'near-mint',
         format: comic.comic.format || 'single-issue',
         estimatedValue: comic.comic.marketValue ? comic.comic.marketValue.toString() : '',
@@ -194,14 +191,6 @@ const EditComicForm: React.FC<EditComicFormProps> = ({ isOpen, onClose, comic })
       newErrors.customPublisher = 'Custom publisher name is required'
     }
 
-    if (!formData.publicationYear.trim()) {
-      newErrors.publicationYear = 'Publication year is required'
-    } else {
-      const year = parseInt(formData.publicationYear)
-      if (isNaN(year) || year < 1800 || year > new Date().getFullYear() + 1) {
-        newErrors.publicationYear = 'Please enter a valid year (1800 or later)'
-      }
-    }
 
     if (formData.estimatedValue && isNaN(parseFloat(formData.estimatedValue))) {
       newErrors.estimatedValue = 'Please enter a valid amount'
@@ -244,7 +233,6 @@ const EditComicForm: React.FC<EditComicFormProps> = ({ isOpen, onClose, comic })
         title: formData.title.trim(),
         issueNumber: formData.issueNumber.trim(),
         publisher: formData.publisher === 'Other' ? formData.customPublisher.trim() : formData.publisher,
-        publicationYear: parseInt(formData.publicationYear),
         condition: formData.condition,
         format: formData.format,
         estimatedValue: formData.estimatedValue ? parseFloat(formData.estimatedValue) : null,
@@ -390,41 +378,20 @@ const EditComicForm: React.FC<EditComicFormProps> = ({ isOpen, onClose, comic })
               </div>
             )}
 
-            {/* Publication Year and Format */}
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-              <div>
-                <label className="block font-persona-aura font-semibold text-ink-black mb-2">
-                  Publication Year *
-                </label>
-                <input
-                  type="number"
-                  value={formData.publicationYear}
-                  onChange={(e) => handleChange('publicationYear', e.target.value)}
-                  className={`w-full p-3 border-2 comic-border font-persona-aura focus:outline-none focus:ring-2 focus:ring-stan-lee-blue ${
-                    errors.publicationYear ? 'border-red-500' : 'border-ink-black'
-                  }`}
-                  placeholder="e.g., 2024"
-                  min="1800"
-                  max={new Date().getFullYear() + 1}
-                  required
-                />
-                {errors.publicationYear && <p className="mt-1 text-sm text-red-600 font-persona-aura">{errors.publicationYear}</p>}
-              </div>
-
-              <div>
-                <label className="block font-persona-aura font-semibold text-ink-black mb-2">
-                  Format
-                </label>
-                <select
-                  value={formData.format}
-                  onChange={(e) => handleChange('format', e.target.value)}
-                  className="w-full p-3 border-2 border-ink-black comic-border font-persona-aura focus:outline-none focus:ring-2 focus:ring-stan-lee-blue"
-                >
-                  {formatOptions.map(format => (
-                    <option key={format.value} value={format.value}>{format.label}</option>
-                  ))}
-                </select>
-              </div>
+            {/* Format */}
+            <div>
+              <label className="block font-persona-aura font-semibold text-ink-black mb-2">
+                Format
+              </label>
+              <select
+                value={formData.format}
+                onChange={(e) => handleChange('format', e.target.value)}
+                className="w-full p-3 border-2 border-ink-black comic-border font-persona-aura focus:outline-none focus:ring-2 focus:ring-stan-lee-blue"
+              >
+                {formatOptions.map(format => (
+                  <option key={format.value} value={format.value}>{format.label}</option>
+                ))}
+              </select>
             </div>
           </div>
 

--- a/src/services/collectionService.ts
+++ b/src/services/collectionService.ts
@@ -9,7 +9,6 @@ export interface SupabaseComic {
   publisher: string
   cover_image: string
   market_value: number
-  publication_year?: number
   format?: string
   is_key_issue?: boolean
   key_issue_reason?: string
@@ -41,9 +40,7 @@ const transformCollectionEntry = (entry: SupabaseUserCollectionEntry): Collectio
     issue: entry.comic.issue,
     issueNumber: parseInt(entry.comic.issue.replace('#', '')) || 0,
     publisher: entry.comic.publisher,
-    publishDate: entry.comic.publication_year ? 
-      new Date(entry.comic.publication_year, 0, 1).toISOString() : 
-      new Date().toISOString(),
+    publishDate: new Date().toISOString(),
     coverImage: entry.comic.cover_image,
     creators: [], // This should be populated from your schema
     format: (entry.comic.format as any) || 'single-issue',
@@ -114,7 +111,6 @@ export const fetchUserCollection = async (
         publisher,
         cover_image,
         market_value,
-        publication_year,
         format,
         is_key_issue,
         key_issue_reason,
@@ -184,7 +180,7 @@ export const fetchUserCollection = async (
       ascending = false // Most recent first
       break
     case 'publish-date':
-      orderColumn = 'comic.publication_year'
+      orderColumn = 'comic.created_at'
       ascending = false // Most recent first
       break
     case 'purchase-date':
@@ -242,7 +238,6 @@ export const getCollectionCount = async (
         issue,
         publisher,
         market_value,
-        publication_year
       )
     `, { count: 'exact', head: true })
     .eq('user_id', user.id)
@@ -312,7 +307,6 @@ export const fetchUserCollectionEntryById = async (entryId: string, userEmail: s
         publisher,
         cover_image,
         market_value,
-        publication_year,
         format,
         is_key_issue,
         key_issue_reason,
@@ -365,7 +359,6 @@ export interface CreateComicData {
   title: string
   issueNumber: string
   publisher: string
-  publicationYear: number
   format: string
   estimatedValue?: number | null
   coverImageUrl?: string | null
@@ -378,7 +371,6 @@ export interface AddComicData {
   title: string
   issueNumber: string
   publisher: string
-  publicationYear: number
   condition: string
   format: string
   estimatedValue?: number | null
@@ -412,7 +404,6 @@ export const findOrCreateComic = async (comicData: CreateComicData): Promise<Sup
     title: comicData.title,
     issue: comicData.issueNumber,
     publisher: comicData.publisher,
-    publication_year: comicData.publicationYear,
     format: comicData.format,
     market_value: comicData.estimatedValue || 0,
     cover_image: comicData.coverImageUrl || '',
@@ -472,7 +463,6 @@ export const addToCollection = async (userEmail: string, collectionData: AddToCo
         publisher,
         cover_image,
         market_value,
-        publication_year,
         format,
         is_key_issue,
         key_issue_reason,
@@ -565,7 +555,6 @@ export const updateCollectionEntry = async (
         publisher,
         cover_image,
         market_value,
-        publication_year,
         format,
         is_key_issue,
         key_issue_reason,
@@ -647,7 +636,6 @@ export const fetchAllComicsForUser = async (userEmail: string): Promise<Collecti
         publisher,
         cover_image,
         market_value,
-        publication_year,
         format,
         is_key_issue,
         key_issue_reason,
@@ -720,7 +708,6 @@ export const fetchComicById = async (comicId: string): Promise<CollectionComic> 
         publisher,
         cover_image,
         market_value,
-        publication_year,
         format,
         is_key_issue,
         key_issue_reason,

--- a/src/services/collectionService.ts
+++ b/src/services/collectionService.ts
@@ -494,7 +494,6 @@ export const addComic = async (userEmail: string, comicData: AddComicData): Prom
     title: comicData.title,
     issueNumber: comicData.issueNumber,
     publisher: comicData.publisher,
-    publicationYear: comicData.publicationYear,
     format: comicData.format,
     estimatedValue: comicData.estimatedValue,
     coverImageUrl: comicData.coverImageUrl,

--- a/src/services/homeService.ts
+++ b/src/services/homeService.ts
@@ -35,7 +35,8 @@ export const fetchUserStats = async (userId: string): Promise<UserStats> => {
   const { data: collectionEntries, error: comicsError } = await supabase
     .from('user_collection_entries')
     .select(`
-      comic:comics!inner(market_value)
+      *,
+      comic:comics(market_value)
     `)
     .eq('user_id', user.id)
 
@@ -44,7 +45,10 @@ export const fetchUserStats = async (userId: string): Promise<UserStats> => {
   }
 
   const totalComics = collectionEntries?.length || 0
-  const collectionValue = collectionEntries?.reduce((sum, entry) => sum + (entry.comic.market_value || 0), 0) || 0
+  const collectionValue = collectionEntries?.reduce((sum, entry) => {
+    const marketValue = Array.isArray(entry.comic) ? entry.comic[0]?.market_value : entry.comic?.market_value
+    return sum + (marketValue || 0)
+  }, 0) || 0
 
   // Get active alerts count (assuming alerts table exists)
   const { count: alertsCount, error: alertsError } = await supabase

--- a/src/services/homeService.ts
+++ b/src/services/homeService.ts
@@ -25,18 +25,26 @@ export const fetchUserStats = async (userId: string): Promise<UserStats> => {
     throw new Error('User ID is required')
   }
 
-  // Get total comics count and collection value
-  const { data: comics, error: comicsError } = await supabase
-    .from('comics')
-    .select('market_value')
-    .eq('user_id', userId)
+  // Get total comics count and collection value from user collection
+  const { data: { user }, error: authError } = await supabase.auth.getUser()
+  
+  if (authError || !user) {
+    throw new Error('User not authenticated')
+  }
+
+  const { data: collectionEntries, error: comicsError } = await supabase
+    .from('user_collection_entries')
+    .select(`
+      comic:comics!inner(market_value)
+    `)
+    .eq('user_id', user.id)
 
   if (comicsError) {
     throw new Error(`Failed to fetch user stats: ${comicsError.message}`)
   }
 
-  const totalComics = comics?.length || 0
-  const collectionValue = comics?.reduce((sum, comic) => sum + (comic.market_value || 0), 0) || 0
+  const totalComics = collectionEntries?.length || 0
+  const collectionValue = collectionEntries?.reduce((sum, entry) => sum + (entry.comic.market_value || 0), 0) || 0
 
   // Get active alerts count (assuming alerts table exists)
   const { count: alertsCount, error: alertsError } = await supabase
@@ -49,15 +57,15 @@ export const fetchUserStats = async (userId: string): Promise<UserStats> => {
     console.warn('Failed to fetch alerts count:', alertsError.message)
   }
 
-  // Get recent additions (comics added in last 7 days)
+  // Get recent additions (collection entries added in last 7 days)
   const sevenDaysAgo = new Date()
   sevenDaysAgo.setDate(sevenDaysAgo.getDate() - 7)
   
   const { count: recentCount, error: recentError } = await supabase
-    .from('comics')
+    .from('user_collection_entries')
     .select('*', { count: 'exact', head: true })
-    .eq('user_id', userId)
-    .gte('created_at', sevenDaysAgo.toISOString())
+    .eq('user_id', user.id)
+    .gte('added_date', sevenDaysAgo.toISOString())
 
   if (recentError) {
     console.warn('Failed to fetch recent additions count:', recentError.message)
@@ -71,7 +79,7 @@ export const fetchUserStats = async (userId: string): Promise<UserStats> => {
   }
 }
 
-// Fetch hot/trending comics (most recently added across all users)
+// Fetch hot/trending comics (most recently added to master list)
 export const fetchHotComics = async (): Promise<HotComic[]> => {
   const { data: comics, error } = await supabase
     .from('comics')

--- a/src/services/searchService.ts
+++ b/src/services/searchService.ts
@@ -8,7 +8,6 @@ export interface SearchResultComic {
   publisher: string
   coverImageUrl: string
   marketValue: number
-  publicationYear?: number
   isKeyIssue?: boolean
   keyIssueReason?: string
 }
@@ -22,7 +21,6 @@ const transformSearchResult = (data: any): SearchResultComic => {
     publisher: data.publisher,
     coverImageUrl: data.cover_image,
     marketValue: data.market_value || 0,
-    publicationYear: data.publication_year,
     isKeyIssue: data.is_key_issue || false,
     keyIssueReason: data.key_issue_reason
   }
@@ -45,7 +43,6 @@ export const searchPublicComics = async (searchTerm: string): Promise<SearchResu
       publisher,
       cover_image,
       market_value,
-      publication_year,
       is_key_issue,
       key_issue_reason
     `)


### PR DESCRIPTION
Fixes #205

Removed all references to `publication_year` column that doesn't exist in the database:

- Updated all SQL queries to remove `publication_year` selections
- Removed `publicationYear` from TypeScript interfaces
- Fixed homeService.ts to use proper collection structure
- Updated UI to not display publication year
- Changed publish-date sorting to use created_at instead

Generated with [Claude Code](https://claude.ai/code)