### PR TITLE
fix: replace key_issue_reason with key_notes

### DIFF
--- a/scripts/import-comics-data.ts
+++ b/scripts/import-comics-data.ts
@@ -40,7 +40,7 @@ interface CSVComicRow {
   variant_description?: string
   is_variant?: string
   is_key_issue?: string
-  key_issue_reason?: string
+  key_notes?: string
   story_arcs?: string
   characters?: string
   teams?: string
@@ -69,7 +69,7 @@ interface ComicInsertData {
   variant_description?: string | null
   is_variant: boolean
   is_key_issue: boolean
-  key_issue_reason?: string | null
+  key_notes?: string | null
   story_arcs?: string[] | null
   characters?: string[] | null
   teams?: string[] | null
@@ -133,7 +133,7 @@ function transformCSVRowToComic(row: CSVComicRow): ComicInsertData {
     variant_description: row.variant_description || null,
     is_variant: row.is_variant?.toLowerCase() === 'true',
     is_key_issue: row.is_key_issue?.toLowerCase() === 'true',
-    key_issue_reason: row.key_issue_reason || null,
+    key_notes: row.key_notes || null,
     story_arcs: parseStringArray(row.story_arcs),
     characters: parseStringArray(row.characters),
     teams: parseStringArray(row.teams),

--- a/src/components/features/AddComicForm.tsx
+++ b/src/components/features/AddComicForm.tsx
@@ -75,7 +75,7 @@ const AddComicForm: React.FC<AddComicFormProps> = ({ isOpen, onClose }) => {
     coverImage: '',
     notes: '',
     isKeyIssue: false,
-    keyIssueReason: '',
+    keyNotes: '',
   })
 
   const [selectedFile, setSelectedFile] = useState<File | null>(null)
@@ -162,7 +162,7 @@ const AddComicForm: React.FC<AddComicFormProps> = ({ isOpen, onClose }) => {
       coverImage: '',
       notes: '',
       isKeyIssue: false,
-      keyIssueReason: '',
+      keyNotes: '',
     })
     setSelectedFile(null)
     setPreviewUrl('')
@@ -245,7 +245,7 @@ const AddComicForm: React.FC<AddComicFormProps> = ({ isOpen, onClose }) => {
         coverImageUrl: coverImageUrl || null,
         notes: formData.notes.trim() || null,
         isKeyIssue: formData.isKeyIssue,
-        keyIssueReason: formData.keyIssueReason.trim() || null,
+        keyNotes: formData.keyNotes.trim() || null,
         addedDate: new Date().toISOString(),
       }
 
@@ -602,8 +602,8 @@ const AddComicForm: React.FC<AddComicFormProps> = ({ isOpen, onClose }) => {
                   </label>
                   <input
                     type="text"
-                    value={formData.keyIssueReason}
-                    onChange={(e) => handleChange('keyIssueReason', e.target.value)}
+                    value={formData.keyNotes}
+                    onChange={(e) => handleChange('keyNotes', e.target.value)}
                     className="w-full p-3 border-2 border-ink-black comic-border font-persona-aura focus:outline-none focus:ring-2 focus:ring-stan-lee-blue"
                     placeholder="e.g., First appearance of Spider-Man"
                   />

--- a/src/components/features/ComicSearchModal.tsx
+++ b/src/components/features/ComicSearchModal.tsx
@@ -270,7 +270,7 @@ const ComicSearchModal: React.FC<ComicSearchModalProps> = ({ isOpen, onClose }) 
                             {comic.is_key_issue && (
                               <p className="font-persona-aura text-kirby-red font-semibold mb-1">
                                 ⭐ Key Issue
-                                {comic.key_issue_reason && `: ${comic.key_issue_reason}`}
+                                {comic.key_notes && `: ${comic.key_notes}`}
                               </p>
                             )}
                             <p className="font-persona-aura text-stan-lee-blue font-semibold">

--- a/src/components/features/EditComicForm.tsx
+++ b/src/components/features/EditComicForm.tsx
@@ -76,7 +76,7 @@ const EditComicForm: React.FC<EditComicFormProps> = ({ isOpen, onClose, comic })
     coverImage: '',
     notes: '',
     isKeyIssue: false,
-    keyIssueReason: '',
+    keyNotes: '',
   })
 
   const [selectedFile, setSelectedFile] = useState<File | null>(null)
@@ -102,7 +102,7 @@ const EditComicForm: React.FC<EditComicFormProps> = ({ isOpen, onClose, comic })
         coverImage: comic.comic.coverImage || '',
         notes: comic.notes || '',
         isKeyIssue: comic.comic.isKeyIssue || false,
-        keyIssueReason: comic.comic.keyIssueReason || '',
+        keyNotes: comic.comic.keyIssueReason || '',
       })
       setPreviewUrl('')
       setSelectedFile(null)
@@ -242,7 +242,7 @@ const EditComicForm: React.FC<EditComicFormProps> = ({ isOpen, onClose, comic })
         coverImageUrl: coverImageUrl || null,
         notes: formData.notes.trim() || null,
         isKeyIssue: formData.isKeyIssue,
-        keyIssueReason: formData.keyIssueReason.trim() || null,
+        keyNotes: formData.keyNotes.trim() || null,
         addedDate: new Date().toISOString(),
       }
 
@@ -599,8 +599,8 @@ const EditComicForm: React.FC<EditComicFormProps> = ({ isOpen, onClose, comic })
                   </label>
                   <input
                     type="text"
-                    value={formData.keyIssueReason}
-                    onChange={(e) => handleChange('keyIssueReason', e.target.value)}
+                    value={formData.keyNotes}
+                    onChange={(e) => handleChange('keyNotes', e.target.value)}
                     className="w-full p-3 border-2 border-ink-black comic-border font-persona-aura focus:outline-none focus:ring-2 focus:ring-stan-lee-blue"
                     placeholder="e.g., First appearance of Spider-Man"
                   />

--- a/src/components/features/EditComicForm.tsx
+++ b/src/components/features/EditComicForm.tsx
@@ -102,7 +102,7 @@ const EditComicForm: React.FC<EditComicFormProps> = ({ isOpen, onClose, comic })
         coverImage: comic.comic.coverImage || '',
         notes: comic.notes || '',
         isKeyIssue: comic.comic.isKeyIssue || false,
-        keyNotes: comic.comic.keyIssueReason || '',
+        keyNotes: comic.comic.keyNotes || '',
       })
       setPreviewUrl('')
       setSelectedFile(null)

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -67,7 +67,7 @@ export interface Comic {
   variantDescription?: string;
   isVariant: boolean;
   isKeyIssue: boolean;
-  keyIssueReason?: string;
+  keyNotes?: string;
   storyArcs?: string[];
   characters?: string[];
   teams?: string[];

--- a/src/pages/ComicDetailPage.tsx
+++ b/src/pages/ComicDetailPage.tsx
@@ -246,14 +246,14 @@ const ComicDetailPage: React.FC = () => {
                 </div>
               </div>
 
-              {comic.isKeyIssue && comic.keyIssueReason && (
+              {comic.isKeyIssue && comic.keyNotes && (
                 <div className="bg-golden-age-yellow bg-opacity-20 border-2 border-golden-age-yellow p-4">
                   <div className="flex items-start space-x-2">
                     <Star size={20} className="text-golden-age-yellow mt-0.5" />
                     <div>
                       <p className="font-super-squad text-sm text-ink-black mb-1">KEY ISSUE</p>
                       <p className="font-persona-aura text-ink-black">
-                        {comic.keyIssueReason}
+                        {comic.keyNotes}
                       </p>
                     </div>
                   </div>

--- a/src/services/collectionService.ts
+++ b/src/services/collectionService.ts
@@ -46,7 +46,7 @@ const transformCollectionEntry = (entry: SupabaseUserCollectionEntry): Collectio
     format: (entry.comic.format as any) || 'single-issue',
     isVariant: false,
     isKeyIssue: entry.comic.is_key_issue || false,
-    keyIssueReason: entry.comic.key_notes,
+    keyNotes: entry.comic.key_notes,
     prices: [],
     marketValue: entry.comic.market_value,
     lastUpdated: entry.comic.updated_at

--- a/src/services/collectionService.ts
+++ b/src/services/collectionService.ts
@@ -11,7 +11,7 @@ export interface SupabaseComic {
   market_value: number
   format?: string
   is_key_issue?: boolean
-  key_issue_reason?: string
+  key_notes?: string
   created_at: string
   updated_at: string
 }
@@ -46,7 +46,7 @@ const transformCollectionEntry = (entry: SupabaseUserCollectionEntry): Collectio
     format: (entry.comic.format as any) || 'single-issue',
     isVariant: false,
     isKeyIssue: entry.comic.is_key_issue || false,
-    keyIssueReason: entry.comic.key_issue_reason,
+    keyIssueReason: entry.comic.key_notes,
     prices: [],
     marketValue: entry.comic.market_value,
     lastUpdated: entry.comic.updated_at
@@ -113,7 +113,7 @@ export const fetchUserCollection = async (
         market_value,
         format,
         is_key_issue,
-        key_issue_reason,
+        key_notes,
         created_at,
         updated_at
       )
@@ -309,7 +309,7 @@ export const fetchUserCollectionEntryById = async (entryId: string, userEmail: s
         market_value,
         format,
         is_key_issue,
-        key_issue_reason,
+        key_notes,
         created_at,
         updated_at
       )
@@ -363,7 +363,7 @@ export interface CreateComicData {
   estimatedValue?: number | null
   coverImageUrl?: string | null
   isKeyIssue: boolean
-  keyIssueReason?: string | null
+  keyNotes?: string | null
 }
 
 // Combined interface for the add comic form (backwards compatibility)
@@ -380,7 +380,7 @@ export interface AddComicData {
   coverImageUrl?: string | null
   notes?: string | null
   isKeyIssue: boolean
-  keyIssueReason?: string | null
+  keyNotes?: string | null
   addedDate: string
 }
 
@@ -408,7 +408,7 @@ export const findOrCreateComic = async (comicData: CreateComicData): Promise<Sup
     market_value: comicData.estimatedValue || 0,
     cover_image: comicData.coverImageUrl || '',
     is_key_issue: comicData.isKeyIssue,
-    key_issue_reason: comicData.keyIssueReason
+    key_notes: comicData.keyNotes
   }
 
   const { data, error } = await supabase
@@ -465,7 +465,7 @@ export const addToCollection = async (userEmail: string, collectionData: AddToCo
         market_value,
         format,
         is_key_issue,
-        key_issue_reason,
+        key_notes,
         created_at,
         updated_at
       )
@@ -498,7 +498,7 @@ export const addComic = async (userEmail: string, comicData: AddComicData): Prom
     estimatedValue: comicData.estimatedValue,
     coverImageUrl: comicData.coverImageUrl,
     isKeyIssue: comicData.isKeyIssue,
-    keyIssueReason: comicData.keyIssueReason
+    keyNotes: comicData.keyNotes
   })
 
   // Then add it to the user's collection
@@ -556,7 +556,7 @@ export const updateCollectionEntry = async (
         market_value,
         format,
         is_key_issue,
-        key_issue_reason,
+        key_notes,
         created_at,
         updated_at
       )
@@ -637,7 +637,7 @@ export const fetchAllComicsForUser = async (userEmail: string): Promise<Collecti
         market_value,
         format,
         is_key_issue,
-        key_issue_reason,
+        key_notes,
         created_at,
         updated_at
       )
@@ -709,7 +709,7 @@ export const fetchComicById = async (comicId: string): Promise<CollectionComic> 
         market_value,
         format,
         is_key_issue,
-        key_issue_reason,
+        key_notes,
         created_at,
         updated_at
       )

--- a/src/services/searchService.ts
+++ b/src/services/searchService.ts
@@ -9,7 +9,7 @@ export interface SearchResultComic {
   coverImageUrl: string
   marketValue: number
   isKeyIssue?: boolean
-  keyIssueReason?: string
+  keyNotes?: string
 }
 
 // Transform Supabase data to SearchResultComic format
@@ -22,7 +22,7 @@ const transformSearchResult = (data: any): SearchResultComic => {
     coverImageUrl: data.cover_image,
     marketValue: data.market_value || 0,
     isKeyIssue: data.is_key_issue || false,
-    keyIssueReason: data.key_issue_reason
+    keyNotes: data.key_notes
   }
 }
 
@@ -44,7 +44,7 @@ export const searchPublicComics = async (searchTerm: string): Promise<SearchResu
       cover_image,
       market_value,
       is_key_issue,
-      key_issue_reason
+      key_notes
     `)
     .ilike('title', `%${trimmedSearch}%`)
     .order('title', { ascending: true })

--- a/src/utils/csvExport.ts
+++ b/src/utils/csvExport.ts
@@ -36,7 +36,7 @@ export const generateCSV = (comics: CollectionComic[]): string => {
     comic.comic.publishDate ? new Date(comic.comic.publishDate).getFullYear().toString() : '',
     comic.comic.format || '',
     comic.comic.isKeyIssue ? 'Yes' : 'No',
-    comic.comic.keyIssueReason || '',
+    comic.comic.keyNotes || '',
     comic.notes || '',
     comic.addedDate ? new Date(comic.addedDate).toLocaleDateString() : ''
   ])


### PR DESCRIPTION
Fixes #207

This PR removes all references to `key_issue_reason` from the codebase and replaces them with `key_notes` to align with the actual database schema.

**Changes Made:**
- Updated TypeScript interfaces in collectionService.ts and searchService.ts
- Fixed database queries to use `key_notes` column
- Updated ComicSearchModal component to display key notes properly
- Fixed import script to handle `key_notes` field
- Left historical migration files unchanged

**Testing:**
- Verified no remaining references to `key_issue_reason` in TypeScript files
- All database queries now use the correct `key_notes` column

Generated with [Claude Code](https://claude.ai/code)