### PR TITLE
fix: Add null check for collectionEntry.id in ComicDetailPage

### DIFF
--- a/src/pages/ComicDetailPage.tsx
+++ b/src/pages/ComicDetailPage.tsx
@@ -63,10 +63,13 @@ const ComicDetailPage: React.FC = () => {
       if (!collectionEntry) {
         throw new Error('Comic not in collection')
       }
-      if (!user || !user.email) {
+      if (!collectionEntry.id) {
+        throw new Error('Collection entry ID not found')
+      }
+      if (!user?.email) {
         throw new Error('User email not found')
       }
-      return removeFromCollection(collectionEntry.id, user.email!)
+      return removeFromCollection(collectionEntry.id, user.email)
     },
     onSuccess: () => {
       // Invalidate collection queries


### PR DESCRIPTION
Fixes persistent TypeScript error on line 69 of ComicDetailPage.tsx that was blocking production deployment.

## Changes
- Add explicit null check for `collectionEntry.id` before passing to `removeFromCollection`
- Improve user email validation with optional chaining
- Remove non-null assertion operator as no longer needed
- Add descriptive error message for missing collection entry ID

## Problem
TypeScript error: "Argument of type 'string | undefined' is not assignable to parameter of type 'string'"

The `CollectionComic` interface has `id?: string` (optional), but `removeFromCollection` expects `entryId: string` (required).

## Solution
Added robust null/undefined checks that guarantee no undefined values reach the `removeFromCollection` function.

Closes #221

Generated with [Claude Code](https://claude.ai/code)