### PR TITLE
Fix toast notification positioning and clipping issues

### DIFF
--- a/src/components/ui/Toast.tsx
+++ b/src/components/ui/Toast.tsx
@@ -53,7 +53,7 @@ const Toast: React.FC<ToastProps> = ({
   }
 
   return (
-    <div className={`fixed top-4 right-4 z-50 max-w-md w-full mx-4 transform transition-all duration-300 ease-in-out`}>
+    <div className={`max-w-sm w-full transform transition-all duration-300 ease-in-out`}>
       <div className={`${getBgColor()} border-2 comic-border shadow-comic p-4 flex items-start space-x-3`}>
         {getIcon()}
         <div className="flex-1 min-w-0">

--- a/src/components/ui/ToastContainer.tsx
+++ b/src/components/ui/ToastContainer.tsx
@@ -8,16 +8,17 @@ const ToastContainer: React.FC = () => {
   if (toasts.length === 0) return null
 
   return (
-    <div className="fixed top-0 right-0 z-50 p-4 space-y-2">
-      {toasts.map((toast, index) => (
-        <div
-          key={toast.id}
-          className="transform transition-all duration-300 ease-in-out"
-          style={{ 
-            transform: `translateY(${index * 10}px)`,
-            zIndex: 1000 - index
-          }}
-        >
+    <div className="fixed top-4 right-4 z-[9999] pointer-events-none">
+      <div className="max-w-sm w-[calc(100vw-2rem)] sm:w-full space-y-2">
+        {toasts.map((toast, index) => (
+          <div
+            key={toast.id}
+            className="transform transition-all duration-300 ease-in-out pointer-events-auto"
+            style={{ 
+              transform: `translateY(${index * 8}px)`,
+              zIndex: 1000 - index
+            }}
+          >
           <Toast
             id={toast.id}
             type={toast.type}
@@ -26,10 +27,10 @@ const ToastContainer: React.FC = () => {
             duration={toast.duration}
             onClose={removeToast}
           />
-        </div>
-      ))}
+          </div>
+        ))}
+      </div>
     </div>
   )
-}
 
 export default ToastContainer


### PR DESCRIPTION
Fixes toast notifications clipping off screen by:

- Removing fixed positioning from Toast.tsx to prevent clipping
- Adding responsive width handling with calc(100vw-2rem) for mobile
- Increasing z-index to 9999 for proper stacking
- Adding pointer-events handling to prevent interaction issues
- Reducing toast offset from 10px to 8px for better spacing

Fixes #229

Generated with [Claude Code](https://claude.ai/code)