### PR TITLE
fix: redirect users back to comic page after login

### DIFF
--- a/src/pages/AuthPage.tsx
+++ b/src/pages/AuthPage.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react'
-import { useNavigate } from 'react-router-dom'
+import { useNavigate, useSearchParams } from 'react-router-dom'
 import { 
   Eye, 
   EyeOff, 
@@ -18,6 +18,7 @@ type AuthMode = 'signin' | 'signup' | 'forgot'
 
 const AuthPage: React.FC = () => {
   const navigate = useNavigate()
+  const [searchParams] = useSearchParams()
   const [mode, setMode] = useState<AuthMode>('signin')
   const [showPassword, setShowPassword] = useState(false)
   const [showConfirmPassword, setShowConfirmPassword] = useState(false)
@@ -57,7 +58,10 @@ const AuthPage: React.FC = () => {
           email: data.user.email || '',
           avatar: data.user.user_metadata?.avatar_url || null,
         })
-        navigate('/')
+        
+        // Check for redirect parameter and navigate to it, otherwise go to home
+        const redirectTo = searchParams.get('redirect')
+        navigate(redirectTo || '/')
       }
     } catch (error) {
       setErrors({ auth: 'An unexpected error occurred' })

--- a/src/pages/ComicDetailPage.tsx
+++ b/src/pages/ComicDetailPage.tsx
@@ -145,8 +145,9 @@ const ComicDetailPage: React.FC = () => {
   
   const handleAddToCollection = () => {
     if (!user) {
-      // Redirect to login page
-      navigate('/auth')
+      // Redirect to login page with current URL as redirect parameter
+      const currentPath = window.location.pathname
+      navigate(`/auth?redirect=${encodeURIComponent(currentPath)}`)
       return
     }
     // TODO: Implement add to collection modal/form


### PR DESCRIPTION
**Description**

Implements proper login redirect functionality so users return to the comic page they were viewing instead of being redirected to the home page.

**Changes**
- Pass current page URL as redirect parameter when navigating to login
- Update login success handler to check for redirect parameter
- Redirect to original comic page instead of home after login

**Files Modified**
- `src/pages/ComicDetailPage.tsx`
- `src/pages/AuthPage.tsx`

Fixes #228

Generated with [Claude Code](https://claude.ai/code)