### PR TITLE
feat: Add UK-specific eBay integration features

### DIFF
--- a/src/pages/ComicDetailPage.tsx
+++ b/src/pages/ComicDetailPage.tsx
@@ -178,13 +178,61 @@ const ComicDetailPage: React.FC = () => {
     if (!comic) return
     
     // Create search query with title and issue
-    const searchQuery = `${comic.title} ${comic.issue}`.trim()
+    const searchQuery = `${comic.title} ${comic.issue} comic`.trim()
     
     // Encode the search query to handle special characters
     const encodedQuery = encodeURIComponent(searchQuery)
     
-    // Construct the eBay search URL
-    const ebayUrl = `https://www.ebay.com/sch/i.html?_nkw=${encodedQuery}`
+    // Construct the eBay UK search URL
+    const ebayUrl = `https://www.ebay.co.uk/sch/i.html?_nkw=${encodedQuery}`
+    
+    // Open in new tab
+    window.open(ebayUrl, '_blank', 'noopener,noreferrer')
+  }
+
+  const handleViewLiveListings = () => {
+    if (!comic) return
+    
+    // Create search query with title and issue
+    const searchQuery = `${comic.title} ${comic.issue} comic`.trim()
+    
+    // Encode the search query to handle special characters
+    const encodedQuery = encodeURIComponent(searchQuery)
+    
+    // Construct the eBay UK search URL with UK-only results
+    const ebayUrl = `https://www.ebay.co.uk/sch/i.html?_nkw=${encodedQuery}&LH_PrefLoc=1`
+    
+    // Open in new tab
+    window.open(ebayUrl, '_blank', 'noopener,noreferrer')
+  }
+
+  const handleEndingSoon = () => {
+    if (!comic) return
+    
+    // Create search query with title and issue
+    const searchQuery = `${comic.title} ${comic.issue} comic`.trim()
+    
+    // Encode the search query to handle special characters
+    const encodedQuery = encodeURIComponent(searchQuery)
+    
+    // Construct the eBay UK search URL with ending soonest sort and UK-only results
+    const ebayUrl = `https://www.ebay.co.uk/sch/i.html?_nkw=${encodedQuery}&_sop=1&LH_PrefLoc=1`
+    
+    // Open in new tab
+    window.open(ebayUrl, '_blank', 'noopener,noreferrer')
+  }
+
+  const handleSoldListings = () => {
+    if (!comic) return
+    
+    // Create search query with title and issue
+    const searchQuery = `${comic.title} ${comic.issue} comic`.trim()
+    
+    // Encode the search query to handle special characters
+    const encodedQuery = encodeURIComponent(searchQuery)
+    
+    // Construct the eBay UK search URL for sold listings with UK-only results
+    const ebayUrl = `https://www.ebay.co.uk/sch/i.html?_nkw=${encodedQuery}&LH_Complete=1&LH_PrefLoc=1`
     
     // Open in new tab
     window.open(ebayUrl, '_blank', 'noopener,noreferrer')
@@ -289,6 +337,33 @@ const ComicDetailPage: React.FC = () => {
                 >
                   <ShoppingCart size={18} />
                   <span>Find on eBay</span>
+                </button>
+
+                <button 
+                  onClick={handleViewLiveListings}
+                  className="w-full flex items-center justify-center space-x-2 py-3 border-comic border-ink-black shadow-comic-sm bg-white text-ink-black
+                            transition-all duration-150 hover:translate-y-[-2px] hover:shadow-comic hover:bg-gray-50"
+                >
+                  <TrendingUp size={18} />
+                  <span className="font-persona-aura font-semibold">View Live Listings</span>
+                </button>
+
+                <button 
+                  onClick={handleEndingSoon}
+                  className="w-full flex items-center justify-center space-x-2 py-3 border-comic border-ink-black shadow-comic-sm bg-white text-ink-black
+                            transition-all duration-150 hover:translate-y-[-2px] hover:shadow-comic hover:bg-gray-50"
+                >
+                  <Calendar size={18} />
+                  <span className="font-persona-aura font-semibold">Ending Soon</span>
+                </button>
+
+                <button 
+                  onClick={handleSoldListings}
+                  className="w-full flex items-center justify-center space-x-2 py-3 border-comic border-ink-black shadow-comic-sm bg-white text-ink-black
+                            transition-all duration-150 hover:translate-y-[-2px] hover:shadow-comic hover:bg-gray-50"
+                >
+                  <DollarSign size={18} />
+                  <span className="font-persona-aura font-semibold">Sold Listings</span>
                 </button>
 
                 <button className="w-full flex items-center justify-center space-x-2 py-3 text-stan-lee-blue hover:text-kirby-red transition-colors">


### PR DESCRIPTION
This PR implements UK-centric eBay integration features as requested in issue #238.

## Changes

- Updated base eBay URL to use ebay.co.uk domain
- Added 'View Live Listings' button with UK-only results (LH_PrefLoc=1)
- Added 'Ending Soon' button with ending soonest sort (_sop=1) and UK results
- Added 'Sold Listings' button for market research (LH_Complete=1) with UK results
- Included 'comic' keyword in all search queries for better targeting

All three new buttons include the recommended URL parameters for UK-specific filtering and are integrated into the comic detail page's existing action panel.

Closes #238

Generated with [Claude Code](https://claude.ai/code)