### PR TITLE
Fix #258: Replace deprecated updateComic with updateCollectionEntry

### DIFF
--- a/src/services/collectionService.ts
+++ b/src/services/collectionService.ts
@@ -640,11 +640,6 @@ export const updateCollectionEntry = async (
   return transformCollectionEntry(data)
 }
 
-// Backwards compatible update function
-export const updateComic = async (comicId: string, updatedData: Partial<AddComicData>): Promise<CollectionComic> => {
-  // This function is now deprecated - we need the entry ID, not the comic ID
-  throw new Error('updateComic is deprecated. Use updateCollectionEntry with entry ID instead.')
-}
 
 // Remove a comic from user's collection (delete collection entry)
 export const removeFromCollection = async (entryId: string, userEmail: string): Promise<void> => {


### PR DESCRIPTION
This PR fixes issue #258 by replacing all references to the deprecated `updateComic` function with `updateCollectionEntry`.

## Changes:
- Updated EditComicForm.tsx to use updateCollectionEntry with entryId and userEmail
- Changed function parameters to use AddToCollectionData instead of AddComicData
- Removed deprecated updateComic function from collectionService.ts
- Collection entry updates now properly use entry ID instead of comic ID

Closes #258

Generated with [Claude Code](https://claude.ai/code)