### PR TITLE
Fix #2 - Alert Creation: Connect alert form to comics

### DIFF
--- a/src/pages/ComicDetailPage.tsx
+++ b/src/pages/ComicDetailPage.tsx
@@ -23,6 +23,7 @@ import { addToWishlist, removeFromWishlist, getWishlistItemByComicId } from '@/s
 import LoadingSpinner from '@/components/ui/LoadingSpinner'
 import EditComicForm from '@/components/features/EditComicForm'
 import AddToCollectionModal from '@/components/features/AddToCollectionModal'
+import CreateAlertModal from '@/components/features/CreateAlertModal'
 import ConfirmationModal from '@/components/ui/ConfirmationModal'
 import { toast } from '@/store/toastStore'
 import { useUserStore } from '@/store/userStore'
@@ -37,6 +38,7 @@ const ComicDetailPage: React.FC = () => {
   const [isEditModalOpen, setIsEditModalOpen] = useState(false)
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false)
   const [isAddToCollectionModalOpen, setIsAddToCollectionModalOpen] = useState(false)
+  const [isCreateAlertModalOpen, setIsCreateAlertModalOpen] = useState(false)
 
   // Fetch comic data from master comics table (public access)
   const { data: comic, isLoading, isError, error } = useQuery({
@@ -233,8 +235,8 @@ const ComicDetailPage: React.FC = () => {
       navigate('/auth')
       return
     }
-    // Navigate to alert configuration page
-    navigate(`/alerts/configure/${id}`)
+    // Open alert creation modal
+    setIsCreateAlertModalOpen(true)
   }
 
   const handleFindOnEbay = () => {
@@ -655,6 +657,13 @@ const ComicDetailPage: React.FC = () => {
       <AddToCollectionModal
         isOpen={isAddToCollectionModalOpen}
         onClose={() => setIsAddToCollectionModalOpen(false)}
+        comic={comic}
+      />
+
+      {/* Create Alert Modal */}
+      <CreateAlertModal
+        isOpen={isCreateAlertModalOpen}
+        onClose={() => setIsCreateAlertModalOpen(false)}
         comic={comic}
       />
 


### PR DESCRIPTION
This PR fixes the alert creation form to be properly connected to comics as requested in issue #259.

## Changes:
- Modified CreateAlertModal to accept optional comic prop
- Display comic info (title, issue, publisher, value) when creating alert for specific comic
- Hide alert name field when comic provided - auto-generate name from comic title
- Include comic_id when creating alerts for comics
- Updated ComicDetailPage to open alert modal instead of navigating to non-existent page
- Maintain backward compatibility with general alert creation from AlertsPage

## Requirements Addressed:
1. ✅ Receive the comic_id from the comic detail page
2. ✅ Display the comic title in the form
3. ✅ Include comic_id when creating the alert
4. ✅ Not ask for "alert name" - use comic title instead

Fixes #259

Generated with [Claude Code](https://claude.ai/code)