### PR TITLE
fix: redirect authenticated users to account page instead of home

### DIFF
--- a/src/pages/AuthConfirmPage.tsx
+++ b/src/pages/AuthConfirmPage.tsx
@@ -20,8 +20,8 @@ const AuthConfirmPage: React.FC = () => {
         // First check if user is already authenticated (no token needed)
         const { data: { session } } = await supabase.auth.getSession()
         if (session) {
-          // User is already verified, redirect to home
-          navigate('/')
+          // User is already verified, redirect to account page
+          navigate('/account')
           return
         }
 
@@ -70,9 +70,9 @@ const AuthConfirmPage: React.FC = () => {
           setStatus('success')
           setMessage('Your email has been confirmed successfully!')
           
-          // Redirect to home page after a short delay
+          // Redirect to account page after a short delay
           setTimeout(() => {
-            navigate('/')
+            navigate('/account')
           }, 2000)
         } else {
           setStatus('error')
@@ -125,7 +125,7 @@ const AuthConfirmPage: React.FC = () => {
                 {message}
               </p>
               <p className="font-persona-aura text-sm text-gray-500">
-                Redirecting you to the homepage...
+                Redirecting you to your account page...
               </p>
             </div>
           )}

--- a/src/pages/AuthPage.tsx
+++ b/src/pages/AuthPage.tsx
@@ -60,9 +60,9 @@ const AuthPage: React.FC = () => {
           avatar: data.user.user_metadata?.avatar_url || null,
         })
         
-        // Check for redirect parameter and navigate to it, otherwise go to home
+        // Check for redirect parameter and navigate to it, otherwise go to account page
         const redirectTo = searchParams.get('redirect')
-        navigate(redirectTo || '/')
+        navigate(redirectTo || '/account')
       }
     } catch (error) {
       setErrors({ auth: 'An unexpected error occurred' })


### PR DESCRIPTION
This PR fixes the email verification redirect issue where users were being sent to the home page instead of their account page after authentication.

## Changes
- Updated AuthConfirmPage.tsx to redirect to /account after email verification
- Updated AuthPage.tsx to redirect to /account after successful login (when no redirect param)
- Updated user-facing messages to reflect new redirect destination

This applies to all auth flows: email verification, password reset, and magic link login.

Fixes #300

Generated with [Claude Code](https://claude.ai/code)