### PR TITLE
fix: Preserve redirect destination through email confirmation flow

### DIFF
--- a/src/pages/AuthConfirmPage.tsx
+++ b/src/pages/AuthConfirmPage.tsx
@@ -17,11 +17,16 @@ const AuthConfirmPage: React.FC = () => {
   useEffect(() => {
     const confirmUser = async () => {
       try {
+        // Get redirect parameter from URL
+        const redirectTo = searchParams.get('redirect')
+        console.log('Auth confirmation - redirect parameter:', redirectTo)
+        
         // First check if user is already authenticated (no token needed)
         const { data: { session } } = await supabase.auth.getSession()
         if (session) {
-          // User is already verified, redirect to account page
-          navigate('/account')
+          // User is already verified, redirect to intended destination or account page
+          console.log('User already authenticated, redirecting to:', redirectTo || '/account')
+          navigate(redirectTo || '/account')
           return
         }
 
@@ -35,6 +40,7 @@ const AuthConfirmPage: React.FC = () => {
           token: searchParams.get('token'),
           finalToken: token,
           type,
+          redirectTo,
           allParams: Object.fromEntries(searchParams.entries()),
           hasSession: !!session
         })
@@ -70,9 +76,11 @@ const AuthConfirmPage: React.FC = () => {
           setStatus('success')
           setMessage('Your email has been confirmed successfully!')
           
-          // Redirect to account page after a short delay
+          // Redirect to intended destination or account page after a short delay
+          const finalDestination = redirectTo || '/account'
+          console.log('Email confirmed successfully, redirecting to:', finalDestination)
           setTimeout(() => {
-            navigate('/account')
+            navigate(finalDestination)
           }, 2000)
         } else {
           setStatus('error')
@@ -125,7 +133,7 @@ const AuthConfirmPage: React.FC = () => {
                 {message}
               </p>
               <p className="font-persona-aura text-sm text-gray-500">
-                Redirecting you to your account page...
+                Redirecting you to {searchParams.get('redirect') ? 'your destination' : 'your account page'}...
               </p>
             </div>
           )}

--- a/src/pages/AuthPage.tsx
+++ b/src/pages/AuthPage.tsx
@@ -79,8 +79,9 @@ const AuthPage: React.FC = () => {
           data: {
             full_name: name,
           },
-          // Let our custom trigger handle email confirmation
-          emailRedirectTo: `${window.location.origin}/auth/confirm`,
+          // Let our custom trigger handle email confirmation  
+          // Pass the current redirect parameter to preserve original destination
+          emailRedirectTo: `${window.location.origin}/auth/confirm${searchParams.get('redirect') ? `?redirect=${encodeURIComponent(searchParams.get('redirect')!)}` : ''}`,
         },
       })
 

--- a/src/services/authService.ts
+++ b/src/services/authService.ts
@@ -68,7 +68,7 @@ export const signUp = async (signupData: SignupData): Promise<AuthResult> => {
         data: {
           full_name: signupData.name,
         },
-        emailRedirectTo: `${window.location.origin}/auth/confirm`,
+        emailRedirectTo: `${window.location.origin}/auth/confirm?redirect=${encodeURIComponent(window.location.pathname + window.location.search)}`,
       },
     })
 


### PR DESCRIPTION
Fixes email authentication redirect issue where new users always redirected to home page instead of intended destination.

**Changes:**
- Modified authService.ts to capture current location in email redirect URL
- Updated AuthPage.tsx to pass redirect parameter through signup flow
- Enhanced AuthConfirmPage.tsx to honor redirect parameter after email confirmation
- Added debug logging to trace redirect path for troubleshooting

Closes #302

Generated with [Claude Code](https://claude.ai/code)