### PR TITLE
fix: show proper error message for existing user signups

### DIFF
--- a/src/pages/AuthPage.tsx
+++ b/src/pages/AuthPage.tsx
@@ -86,7 +86,14 @@ const AuthPage: React.FC = () => {
       })
 
       if (error) {
-        setErrors({ auth: error.message })
+        // Check if error is due to user already existing
+        if (error.message?.toLowerCase().includes('already registered') || 
+            error.message?.toLowerCase().includes('email already exists') ||
+            error.message?.toLowerCase().includes('user already exists')) {
+          setErrors({ auth: 'This email is already registered. Please sign in instead.' })
+        } else {
+          setErrors({ auth: error.message })
+        }
         return
       }
 

--- a/src/services/authService.ts
+++ b/src/services/authService.ts
@@ -89,6 +89,15 @@ export const signUp = async (signupData: SignupData): Promise<AuthResult> => {
     console.log('[SIGNUP] Signup response:', data)
 
     if (error) {
+      // Check if error is due to user already existing
+      if (error.message?.toLowerCase().includes('already registered') || 
+          error.message?.toLowerCase().includes('email already exists') ||
+          error.message?.toLowerCase().includes('user already exists')) {
+        return {
+          success: false,
+          error: 'This email is already registered. Please sign in instead.',
+        }
+      }
       return {
         success: false,
         error: error.message,


### PR DESCRIPTION
Fixes the signup flow to show appropriate error messages when existing users try to sign up again.

## Changes
- Add duplicate user detection in authService.ts signUp function
- Add duplicate user detection in AuthPage.tsx handleSignup function
- Show 'This email is already registered. Please sign in instead.' for existing users
- Prevents showing 'check your email' message for duplicate signups

Fixes #315

Generated with [Claude Code](https://claude.ai/code)