### PR TITLE
fix: Fix duplicate user sign-up and email/UUID bug

### DIFF
--- a/src/hooks/useHomeQuery.ts
+++ b/src/hooks/useHomeQuery.ts
@@ -6,14 +6,14 @@ export const useUserStatsQuery = () => {
   const { user } = useUserStore()
 
   return useQuery({
-    queryKey: ['userStats', user?.email],
+    queryKey: ['userStats', user?.id],
     queryFn: () => {
-      if (!user?.email) {
+      if (!user?.id) {
         throw new Error('No user found')
       }
-      return fetchUserStats(user.email)
+      return fetchUserStats(user.id)
     },
-    enabled: !!user?.email,
+    enabled: !!user?.id,
     staleTime: 1000 * 60 * 5, // 5 minutes
     refetchOnWindowFocus: false,
   })

--- a/src/pages/AuthPage.tsx
+++ b/src/pages/AuthPage.tsx
@@ -89,8 +89,10 @@ const AuthPage: React.FC = () => {
         // Check if error is due to user already existing
         if (error.message?.toLowerCase().includes('already registered') || 
             error.message?.toLowerCase().includes('email already exists') ||
-            error.message?.toLowerCase().includes('user already exists')) {
-          setErrors({ auth: 'This email is already registered. Please sign in instead.' })
+            error.message?.toLowerCase().includes('user already exists') ||
+            error.message?.toLowerCase().includes('already been registered') ||
+            error.message?.toLowerCase().includes('duplicate key value')) {
+          setErrors({ auth: 'Email already registered. Please sign in instead.' })
         } else {
           setErrors({ auth: error.message })
         }

--- a/src/services/homeService.ts
+++ b/src/services/homeService.ts
@@ -56,7 +56,7 @@ export const fetchUserStats = async (userId: string): Promise<UserStats> => {
   const { count: alertsCount, error: alertsError } = await supabase
     .from('alerts')
     .select('*', { count: 'exact', head: true })
-    .eq('user_id', userId)
+    .eq('user_id', user.id)
     .eq('is_active', true)
 
   if (alertsError) {


### PR DESCRIPTION
Fixes #317

## Changes
- Fixed alert query in homeService.ts to use user.id (UUID) instead of userId (email)
- Updated useUserStatsQuery hook to pass user.id instead of user.email
- Improved duplicate signup error handling with more error patterns
- Changed duplicate signup message to "Email already registered. Please sign in instead."

## Testing
- Alert queries now use proper UUID instead of email
- Duplicate signup attempts show appropriate error message

Generated with [Claude Code](https://claude.ai/code)