### PR TITLE
feat: add eBay price population admin endpoint

### DIFF
--- a/api/admin/populate-ebay-prices.ts
+++ b/api/admin/populate-ebay-prices.ts
@@ -1,0 +1,75 @@
+interface VercelRequest {
+  method?: string;
+  query: { [key: string]: string | string[] | undefined };
+}
+
+interface VercelResponse {
+  status(code: number): VercelResponse;
+  json(body: any): void;
+}
+
+export default async function handler(
+  request: VercelRequest,
+  response: VercelResponse
+): Promise<void> {
+  try {
+    // Only allow POST requests
+    if (request.method !== 'POST') {
+      return response.status(405).json({ 
+        error: 'Method Not Allowed',
+        message: 'Only POST requests are allowed' 
+      });
+    }
+
+    // Check for authentication key
+    const { key } = request.query;
+    const adminSecret = process.env.ADMIN_SECRET;
+
+    if (!adminSecret) {
+      console.error('ADMIN_SECRET environment variable not set');
+      return response.status(500).json({
+        error: 'Server Configuration Error',
+        message: 'Admin authentication not configured'
+      });
+    }
+
+    if (!key || key !== adminSecret) {
+      return response.status(401).json({
+        error: 'Unauthorized',
+        message: 'Invalid or missing admin key'
+      });
+    }
+
+    // Run the eBay population script
+    console.log('🚀 Starting eBay price population script...');
+    
+    // Since the script runs immediately on import, we need to spawn it as a separate process
+    // to avoid blocking the API response and to handle the script's process.exit calls
+    const { spawn } = await import('child_process');
+    
+    // Use npm run command to execute the script
+    const child = spawn('npm', ['run', 'populate:ebay-prices'], {
+      detached: true,
+      stdio: 'ignore',
+      env: { ...process.env },
+      cwd: process.cwd()
+    });
+    
+    child.unref(); // Allow parent process to exit independently
+
+    // Return success response immediately
+    return response.status(200).json({
+      success: true,
+      message: 'eBay price population started successfully',
+      timestamp: new Date().toISOString()
+    });
+
+  } catch (error) {
+    console.error('❌ API endpoint error:', error);
+    
+    return response.status(500).json({
+      error: 'Internal Server Error',
+      message: error instanceof Error ? error.message : 'Unknown error occurred'
+    });
+  }
+}

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "test:run": "vitest run",
     "gen:types": "supabase gen types typescript --linked > src/lib/database.types.ts",
     "db:seed": "tsx scripts/import-comics-data.ts",
-    "populate:market-values": "tsx scripts/populate-market-values.ts"
+    "populate:market-values": "tsx scripts/populate-market-values.ts",
+    "populate:ebay-prices": "tsx scripts/populate-ebay-prices.ts"
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.56.1",


### PR DESCRIPTION
Creates admin endpoint to run eBay price population

- Add populate:ebay-prices npm script to package.json
- Create /api/admin/populate-ebay-prices.ts endpoint
- Requires ADMIN_SECRET authentication
- Returns success status message
- Similar structure to existing populate-market-values endpoint

Fixes #353

Generated with [Claude Code](https://claude.ai/code)