### PR TITLE
feat: Add ComicVine image integration for comic covers

### DIFF
--- a/api/comicvine/fetch-cover.ts
+++ b/api/comicvine/fetch-cover.ts
@@ -1,0 +1,300 @@
+import { createClient } from '@supabase/supabase-js'
+
+interface VercelRequest {
+  method?: string;
+  query: { [key: string]: string | string[] | undefined };
+}
+
+interface VercelResponse {
+  status(code: number): VercelResponse;
+  json(body: any): void;
+}
+
+interface ComicVineSearchResponse {
+  error: string;
+  limit: number;
+  offset: number;
+  number_of_page_results: number;
+  number_of_total_results: number;
+  status_code: number;
+  results?: Array<{
+    id: number;
+    name: string;
+    issue_number: string;
+    volume: {
+      name: string;
+      id: number;
+    };
+    image?: {
+      icon_url: string;
+      medium_url: string;
+      screen_url: string;
+      screen_large_url: string;
+      small_url: string;
+      super_url: string;
+      thumb_url: string;
+      tiny_url: string;
+      original_url: string;
+    };
+    cover_date: string;
+    description: string;
+  }>;
+}
+
+interface Comic {
+  id: string;
+  title: string;
+  issue: string;
+  publisher: string;
+  cover_image?: string;
+}
+
+export default async function handler(
+  request: VercelRequest,
+  response: VercelResponse
+): Promise<void> {
+  // Only allow POST requests
+  if (request.method !== 'POST') {
+    return response.status(405).json({ error: 'Method Not Allowed' });
+  }
+
+  try {
+    const { comic_id } = request.query;
+
+    // Validate required parameters
+    if (!comic_id || typeof comic_id !== 'string') {
+      return response.status(400).json({ 
+        error: 'Missing required parameter: comic_id' 
+      });
+    }
+
+    // Initialize Supabase client
+    const supabaseUrl = process.env.VITE_SUPABASE_URL;
+    const supabaseServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+    
+    if (!supabaseUrl || !supabaseServiceKey) {
+      return response.status(500).json({
+        error: 'Supabase configuration missing',
+        message: 'VITE_SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY environment variables are required'
+      });
+    }
+
+    const supabase = createClient(supabaseUrl, supabaseServiceKey, {
+      auth: {
+        autoRefreshToken: false,
+        persistSession: false
+      }
+    });
+
+    // ComicVine API configuration
+    const API_KEY = process.env.COMICVINE_API_KEY;
+    if (!API_KEY) {
+      return response.status(500).json({
+        error: 'ComicVine API key not configured',
+        message: 'COMICVINE_API_KEY environment variable is required'
+      });
+    }
+
+    // Step 1: Get comic details from database
+    const { data: comic, error: fetchError } = await supabase
+      .from('comics')
+      .select('id, title, issue, publisher, cover_image')
+      .eq('id', comic_id)
+      .single();
+
+    if (fetchError || !comic) {
+      return response.status(404).json({
+        error: 'Comic not found',
+        message: `No comic found with ID: ${comic_id}`
+      });
+    }
+
+    // Check if comic already has a cover image
+    if (comic.cover_image && comic.cover_image.trim() !== '') {
+      return response.status(200).json({
+        success: true,
+        message: 'Comic already has cover image',
+        cover_url: comic.cover_image
+      });
+    }
+
+    // Step 2: Search ComicVine API for matching comic
+    const searchQuery = `${comic.title} ${comic.issue}`.trim();
+    console.log(`🔍 Searching ComicVine for: "${searchQuery}"`);
+    
+    const comicVineSearchUrl = new URL('https://comicvine.gamespot.com/api/issues/');
+    comicVineSearchUrl.searchParams.set('api_key', API_KEY);
+    comicVineSearchUrl.searchParams.set('format', 'json');
+    comicVineSearchUrl.searchParams.set('filter', `name:${comic.title}`);
+    comicVineSearchUrl.searchParams.set('field_list', 'id,name,issue_number,volume,image,cover_date,description');
+    comicVineSearchUrl.searchParams.set('limit', '20');
+
+    const searchResponse = await fetch(comicVineSearchUrl.toString(), {
+      method: 'GET',
+      headers: {
+        'User-Agent': 'comic-speculator-tool/1.0'
+      }
+    });
+
+    if (!searchResponse.ok) {
+      console.error('ComicVine search failed:', {
+        status: searchResponse.status,
+        statusText: searchResponse.statusText
+      });
+      return response.status(searchResponse.status).json({
+        error: `ComicVine API error: ${searchResponse.status} ${searchResponse.statusText}`
+      });
+    }
+
+    const searchData: ComicVineSearchResponse = await searchResponse.json() as ComicVineSearchResponse;
+
+    if (searchData.status_code !== 1 || !searchData.results || searchData.results.length === 0) {
+      console.log('❌ No ComicVine search results found');
+      return response.status(404).json({
+        error: 'No matching comic found in ComicVine',
+        message: `No results found for "${searchQuery}"`
+      });
+    }
+
+    // Step 3: Find the best match
+    let bestMatch = searchData.results[0]; // Default to first result
+    
+    for (const result of searchData.results) {
+      // Check for exact issue match
+      const issueMatch = result.issue_number === comic.issue || 
+                        result.issue_number === `#${comic.issue}` ||
+                        comic.issue.includes(result.issue_number || '');
+      
+      // Check for title similarity in volume name
+      const titleMatch = result.volume?.name?.toLowerCase().includes(comic.title.toLowerCase()) ||
+                        comic.title.toLowerCase().includes(result.volume?.name?.toLowerCase() || '');
+      
+      if (issueMatch && titleMatch) {
+        bestMatch = result;
+        break;
+      }
+    }
+
+    if (!bestMatch.image?.medium_url) {
+      console.log('❌ Best match has no cover image');
+      return response.status(404).json({
+        error: 'No cover image available',
+        message: 'Found matching comic but no cover image available'
+      });
+    }
+
+    console.log(`✅ Found match: ${bestMatch.volume?.name} #${bestMatch.issue_number}`);
+
+    // Step 4: Download the cover image (medium size)
+    const imageUrl = bestMatch.image.medium_url;
+    console.log(`📥 Downloading image from: ${imageUrl}`);
+
+    const imageResponse = await fetch(imageUrl, {
+      method: 'GET',
+      headers: {
+        'User-Agent': 'comic-speculator-tool/1.0'
+      }
+    });
+
+    if (!imageResponse.ok) {
+      console.error('Image download failed:', {
+        status: imageResponse.status,
+        statusText: imageResponse.statusText
+      });
+      return response.status(500).json({
+        error: 'Failed to download cover image',
+        message: `Image download failed: ${imageResponse.status} ${imageResponse.statusText}`
+      });
+    }
+
+    const imageBuffer = Buffer.from(await imageResponse.arrayBuffer());
+    const contentType = imageResponse.headers.get('content-type') || 'image/jpeg';
+    
+    // Validate image size (should be around 200KB as requested)
+    if (imageBuffer.length > 1024 * 1024) { // 1MB limit for safety
+      return response.status(400).json({
+        error: 'Image too large',
+        message: `Image size (${Math.round(imageBuffer.length / 1024)}KB) exceeds maximum allowed size`
+      });
+    }
+
+    console.log(`✅ Downloaded image (${Math.round(imageBuffer.length / 1024)}KB)`);
+
+    // Step 5: Upload to Supabase storage in 'comic-covers' bucket
+    const fileName = `${comic_id}-${Date.now()}.${contentType.split('/')[1] || 'jpg'}`;
+    const { data: uploadData, error: uploadError } = await supabase.storage
+      .from('comic-covers')
+      .upload(fileName, imageBuffer, {
+        contentType,
+        cacheControl: '31536000', // Cache for 1 year
+        upsert: false
+      });
+
+    if (uploadError) {
+      console.error('Storage upload failed:', uploadError);
+      return response.status(500).json({
+        error: 'Failed to upload image to storage',
+        message: uploadError.message
+      });
+    }
+
+    // Get the public URL for the uploaded image
+    const { data: { publicUrl } } = supabase.storage
+      .from('comic-covers')
+      .getPublicUrl(fileName);
+
+    console.log(`✅ Uploaded to storage: ${publicUrl}`);
+
+    // Step 6: Update comic.cover_image_url in database
+    const { error: updateError } = await supabase
+      .from('comics')
+      .update({ 
+        cover_image: publicUrl,
+        updated_at: new Date().toISOString()
+      })
+      .eq('id', comic_id);
+
+    if (updateError) {
+      console.error('Database update failed:', updateError);
+      // Try to clean up uploaded file
+      try {
+        await supabase.storage.from('comic-covers').remove([fileName]);
+      } catch (cleanupError) {
+        console.error('Failed to cleanup uploaded file:', cleanupError);
+      }
+      
+      return response.status(500).json({
+        error: 'Failed to update database',
+        message: updateError.message
+      });
+    }
+
+    console.log(`✅ Updated database for comic ${comic_id}`);
+
+    // Step 7: Return success status
+    return response.status(200).json({
+      success: true,
+      comic_id,
+      cover_url: publicUrl,
+      comicvine_match: {
+        id: bestMatch.id,
+        name: bestMatch.volume?.name,
+        issue_number: bestMatch.issue_number,
+        cover_date: bestMatch.cover_date
+      },
+      image_info: {
+        size_kb: Math.round(imageBuffer.length / 1024),
+        content_type: contentType,
+        filename: fileName
+      }
+    });
+
+  } catch (error) {
+    console.error('Internal server error:', error);
+    
+    return response.status(500).json({
+      error: 'Internal Server Error',
+      message: error instanceof Error ? error.message : 'Unknown error occurred'
+    });
+  }
+}

--- a/scripts/populate-comic-covers.ts
+++ b/scripts/populate-comic-covers.ts
@@ -1,0 +1,362 @@
+import { createClient } from '@supabase/supabase-js'
+
+// Environment variables
+const supabaseUrl = process.env.VITE_SUPABASE_URL
+const supabaseServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY
+const baseUrl = process.env.BASE_URL || 'http://localhost:5173' // Default to Vite dev server
+
+if (!supabaseUrl || !supabaseServiceKey) {
+  console.error('Missing required environment variables:')
+  console.error('- VITE_SUPABASE_URL')
+  console.error('- SUPABASE_SERVICE_ROLE_KEY')
+  process.exit(1)
+}
+
+// ComicVine API rate limiting configuration (200 requests per hour)
+const RATE_LIMIT_DELAY_MS = 18 * 1000 // 18 seconds between requests (200/hour = 1 request every 18 seconds)
+const MAX_REQUESTS_PER_SESSION = 190 // Leave some buffer from the 200/hour limit
+
+// Create Supabase admin client
+const supabase = createClient(supabaseUrl, supabaseServiceKey, {
+  auth: {
+    autoRefreshToken: false,
+    persistSession: false
+  }
+})
+
+interface Comic {
+  id: string
+  title: string
+  issue: string
+  publisher: string
+  cover_image?: string | null
+}
+
+interface FetchCoverResponse {
+  success: boolean
+  comic_id?: string
+  cover_url?: string
+  error?: string
+  message?: string
+}
+
+// Progress tracking interface
+interface ProgressState {
+  totalComics: number
+  processedComics: number
+  successfulUpdates: number
+  failedUpdates: number
+  skippedComics: number
+  requestsThisSession: number
+  startTime: string
+  lastProcessedId?: string
+  sessionId: string
+}
+
+// Helper function to fetch comic cover using the API endpoint
+async function fetchComicCover(comicId: string): Promise<FetchCoverResponse> {
+  try {
+    console.log(`📸 Fetching cover for comic ID: ${comicId}`)
+    
+    const response = await fetch(`${baseUrl}/api/comicvine/fetch-cover?comic_id=${encodeURIComponent(comicId)}`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'User-Agent': 'comic-speculator-tool-script/1.0'
+      }
+    })
+    
+    if (!response.ok) {
+      const errorText = await response.text()
+      console.log(`❌ API error ${response.status}: ${response.statusText}`)
+      console.log(`Error details: ${errorText}`)
+      return {
+        success: false,
+        error: `API error ${response.status}: ${response.statusText}`,
+        message: errorText
+      }
+    }
+    
+    const result: FetchCoverResponse = await response.json() as FetchCoverResponse
+    
+    if (result.success) {
+      console.log(`✅ Cover fetched successfully: ${result.cover_url}`)
+    } else {
+      console.log(`❌ Cover fetch failed: ${result.error || 'Unknown error'}`)
+    }
+    
+    return result
+    
+  } catch (error) {
+    console.log(`❌ Fetch error: ${error instanceof Error ? error.message : 'Unknown error'}`)
+    return {
+      success: false,
+      error: 'Request failed',
+      message: error instanceof Error ? error.message : 'Unknown error occurred'
+    }
+  }
+}
+
+// Helper function to save progress state
+async function saveProgress(progress: ProgressState): Promise<void> {
+  const progressFile = 'comic-covers-progress.json'
+  const fs = await import('fs')
+  fs.writeFileSync(progressFile, JSON.stringify(progress, null, 2))
+  console.log(`💾 Progress saved: ${progress.processedComics}/${progress.totalComics} processed`)
+}
+
+// Helper function to load progress state
+async function loadProgress(): Promise<ProgressState | null> {
+  try {
+    const progressFile = 'comic-covers-progress.json'
+    const fs = await import('fs')
+    if (fs.existsSync(progressFile)) {
+      const data = fs.readFileSync(progressFile, 'utf-8')
+      const progress: ProgressState = JSON.parse(data)
+      console.log(`📂 Loaded previous progress: ${progress.processedComics}/${progress.totalComics} processed`)
+      return progress
+    }
+  } catch (error) {
+    console.log('No previous progress found, starting fresh')
+  }
+  return null
+}
+
+// Helper function to wait with rate limiting
+function waitForRateLimit(): Promise<void> {
+  console.log(`⏳ Waiting ${RATE_LIMIT_DELAY_MS / 1000} seconds for ComicVine rate limiting...`)
+  return new Promise(resolve => setTimeout(resolve, RATE_LIMIT_DELAY_MS))
+}
+
+// Helper function to generate session ID
+function generateSessionId(): string {
+  return `session_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`
+}
+
+// Helper function to estimate time remaining
+function estimateTimeRemaining(progress: ProgressState): string {
+  const elapsed = Date.now() - new Date(progress.startTime).getTime()
+  const averageTimePerComic = elapsed / progress.processedComics
+  const remaining = progress.totalComics - progress.processedComics
+  const estimatedMs = remaining * averageTimePerComic
+  
+  const hours = Math.floor(estimatedMs / (1000 * 60 * 60))
+  const minutes = Math.floor((estimatedMs % (1000 * 60 * 60)) / (1000 * 60))
+  
+  if (hours > 0) {
+    return `~${hours}h ${minutes}m`
+  } else {
+    return `~${minutes}m`
+  }
+}
+
+// Main function to populate comic covers
+async function populateComicCovers(): Promise<void> {
+  console.log('🚀 Starting comic cover population from ComicVine...')
+  console.log(`⏰ Rate limit: 200 requests/hour (${RATE_LIMIT_DELAY_MS / 1000}s between requests)`)
+  
+  try {
+    // Load previous progress if available
+    let progress = await loadProgress()
+    const isResuming = !!progress
+    
+    // Get comics that need cover images
+    let query = supabase
+      .from('comics')
+      .select('id, title, issue, publisher, cover_image')
+      .or('cover_image.is.null,cover_image.eq.') // Comics without cover images or empty string
+      .order('created_at', { ascending: true })
+      .limit(1000) // Process in chunks to avoid memory issues
+    
+    // If resuming, start from where we left off
+    if (progress?.lastProcessedId) {
+      console.log(`📍 Resuming from comic ID: ${progress.lastProcessedId}`)
+      query = query.gt('id', progress.lastProcessedId)
+    }
+    
+    const { data: comics, error } = await query
+    
+    if (error) {
+      console.error('❌ Failed to fetch comics:', error.message)
+      process.exit(1)
+    }
+    
+    if (!comics || comics.length === 0) {
+      console.log('🎉 No comics need cover images!')
+      
+      // Clean up progress file if all done
+      if (progress) {
+        try {
+          const fs = await import('fs')
+          fs.unlinkSync('comic-covers-progress.json')
+          console.log('🧹 Cleaned up progress file')
+        } catch (error) {
+          // Ignore cleanup errors
+        }
+      }
+      
+      return
+    }
+    
+    // Initialize or update progress
+    if (!progress) {
+      progress = {
+        totalComics: comics.length,
+        processedComics: 0,
+        successfulUpdates: 0,
+        failedUpdates: 0,
+        skippedComics: 0,
+        requestsThisSession: 0,
+        startTime: new Date().toISOString(),
+        sessionId: generateSessionId()
+      }
+    } else {
+      // Reset session counters but keep cumulative progress
+      progress.requestsThisSession = 0
+      progress.sessionId = generateSessionId()
+    }
+    
+    console.log(`📊 Found ${comics.length} comics to process`)
+    if (isResuming) {
+      console.log(`📈 Previous progress: ${progress.processedComics}/${progress.totalComics} processed, ${progress.successfulUpdates} successful`)
+    }
+    
+    // Process each comic
+    for (let i = 0; i < comics.length; i++) {
+      const comic = comics[i]
+      
+      // Check rate limiting for this session
+      if (progress.requestsThisSession >= MAX_REQUESTS_PER_SESSION) {
+        console.log(`\n⏸️  Reached session request limit (${MAX_REQUESTS_PER_SESSION}). Stopping to respect ComicVine rate limits.`)
+        console.log('💡 Run the script again in an hour to continue processing.')
+        await saveProgress(progress)
+        break
+      }
+      
+      const comicNumber = progress.processedComics + 1
+      const totalComics = progress.totalComics
+      const percentage = Math.round((comicNumber / totalComics) * 100)
+      
+      console.log(`\n🔄 Processing comic ${comicNumber}/${totalComics} (${percentage}%): "${comic.title} #${comic.issue}"`)
+      
+      if (progress.processedComics > 0 && comicNumber % 10 === 0) {
+        const timeRemaining = estimateTimeRemaining(progress)
+        console.log(`📈 Progress update: ${percentage}% complete, estimated time remaining: ${timeRemaining}`)
+      }
+      
+      // Skip comics that already have cover images (in case data changed since query)
+      if (comic.cover_image && comic.cover_image.trim() !== '') {
+        console.log(`⏭️  Skipping - already has cover image`)
+        progress.skippedComics++
+        progress.processedComics++
+        progress.lastProcessedId = comic.id
+        continue
+      }
+      
+      // Fetch cover image using API endpoint
+      const result = await fetchComicCover(comic.id)
+      progress.requestsThisSession++
+      
+      if (result.success) {
+        progress.successfulUpdates++
+        console.log(`✅ Cover added successfully`)
+      } else {
+        progress.failedUpdates++
+        console.log(`❌ Failed to fetch cover: ${result.error}`)
+      }
+      
+      progress.processedComics++
+      progress.lastProcessedId = comic.id
+      
+      // Save progress every 5 comics or if this is the last one
+      if (progress.processedComics % 5 === 0 || i === comics.length - 1) {
+        await saveProgress(progress)
+      }
+      
+      // Rate limiting wait (except for the last comic)
+      if (i < comics.length - 1 && progress.requestsThisSession < MAX_REQUESTS_PER_SESSION) {
+        await waitForRateLimit()
+      }
+    }
+    
+    // Final summary
+    const duration = Date.now() - new Date(progress.startTime).getTime()
+    const durationHours = Math.round(duration / 1000 / 60 / 60 * 10) / 10
+    const durationMinutes = Math.round(duration / 1000 / 60)
+    
+    console.log('\n📈 Population Summary:')
+    console.log(`✅ Successfully updated: ${progress.successfulUpdates} comics`)
+    console.log(`❌ Failed updates: ${progress.failedUpdates} comics`)
+    console.log(`⏭️  Skipped (already have covers): ${progress.skippedComics} comics`)
+    console.log(`📊 Total processed: ${progress.processedComics}/${progress.totalComics} comics`)
+    console.log(`🌐 API requests made this session: ${progress.requestsThisSession}`)
+    
+    if (durationHours >= 1) {
+      console.log(`⏱️  Total session duration: ${durationHours}h`)
+    } else {
+      console.log(`⏱️  Total session duration: ${durationMinutes}m`)
+    }
+    
+    if (progress.processedComics < progress.totalComics) {
+      const remaining = progress.totalComics - progress.processedComics
+      const estimatedHours = Math.ceil(remaining / 200) // 200 per hour
+      console.log(`\n💡 ${remaining} comics remaining. Estimated time to complete: ~${estimatedHours}h`)
+      console.log('Run the script again in an hour to continue processing.')
+    } else {
+      console.log('\n🎉 All comics have been processed!')
+      
+      // Clean up progress file when complete
+      try {
+        const fs = await import('fs')
+        fs.unlinkSync('comic-covers-progress.json')
+        console.log('🧹 Cleaned up progress file')
+      } catch (error) {
+        // Ignore cleanup errors
+      }
+    }
+    
+  } catch (error) {
+    console.error('💥 Population failed:', error)
+    
+    // Save progress even on error
+    if (typeof error === 'object' && error !== null && 'progress' in error) {
+      try {
+        await saveProgress(error.progress as ProgressState)
+        console.log('💾 Progress saved despite error')
+      } catch (saveError) {
+        console.error('Failed to save progress:', saveError)
+      }
+    }
+    
+    process.exit(1)
+  }
+}
+
+// Handle graceful shutdown
+process.on('SIGINT', async () => {
+  console.log('\n⏸️  Received interrupt signal. Saving progress...')
+  
+  // Try to save current progress
+  try {
+    const fs = await import('fs')
+    if (fs.existsSync('comic-covers-progress.json')) {
+      console.log('💾 Progress file exists and will be preserved for resumption')
+    }
+  } catch (error) {
+    console.error('Error checking progress file:', error)
+  }
+  
+  console.log('👋 Shutting down gracefully. Run the script again to resume.')
+  process.exit(0)
+})
+
+// Handle uncaught errors
+process.on('unhandledRejection', (reason, promise) => {
+  console.error('Unhandled Rejection at:', promise, 'reason:', reason)
+  process.exit(1)
+})
+
+// Run the population script
+console.log('🏃 Starting Comic Cover Population Script')
+console.log('Press Ctrl+C to stop gracefully and save progress')
+populateComicCovers().catch(console.error)


### PR DESCRIPTION
Implements ComicVine image integration for comic covers as requested in issue #355.

## Changes
- Created `/api/comicvine/fetch-cover.ts` API endpoint
- Created `/scripts/populate-comic-covers.ts` batch processing script
- Implements 200/hour rate limiting with ComicVine API
- Includes progress saving and resumption capabilities
- Comprehensive error handling and logging

## API Endpoint Features
- Accepts comic_id parameter
- Searches ComicVine for matching comics
- Downloads medium-size cover images (~200KB)
- Uploads to Supabase 'comic-covers' storage bucket
- Updates database with cover image URL

## Script Features
- Processes comics without cover images
- Rate limiting: 18 second delays between requests
- Progress persistence in JSON file
- Graceful shutdown and resumption
- Detailed progress tracking and time estimates

Closes #355

Generated with [Claude Code](https://claude.ai/code)