### PR TITLE
feat: add ComicVine admin API endpoint for cover population

### DIFF
--- a/api/admin/populate-comic-covers.ts
+++ b/api/admin/populate-comic-covers.ts
@@ -1,0 +1,75 @@
+interface VercelRequest {
+  method?: string;
+  query: { [key: string]: string | string[] | undefined };
+}
+
+interface VercelResponse {
+  status(code: number): VercelResponse;
+  json(body: any): void;
+}
+
+export default async function handler(
+  request: VercelRequest,
+  response: VercelResponse
+): Promise<void> {
+  try {
+    // Only allow POST requests
+    if (request.method !== 'POST') {
+      return response.status(405).json({ 
+        error: 'Method Not Allowed',
+        message: 'Only POST requests are allowed' 
+      });
+    }
+
+    // Check for authentication key
+    const { key } = request.query;
+    const adminSecret = process.env.ADMIN_SECRET;
+
+    if (!adminSecret) {
+      console.error('ADMIN_SECRET environment variable not set');
+      return response.status(500).json({
+        error: 'Server Configuration Error',
+        message: 'Admin authentication not configured'
+      });
+    }
+
+    if (!key || key !== adminSecret) {
+      return response.status(401).json({
+        error: 'Unauthorized',
+        message: 'Invalid or missing admin key'
+      });
+    }
+
+    // Run the comic covers population script
+    console.log('🚀 Starting ComicVine cover population script...');
+    
+    // Since the script runs immediately on import, we need to spawn it as a separate process
+    // to avoid blocking the API response and to handle the script's process.exit calls
+    const { spawn } = await import('child_process');
+    
+    // Use npm run command to execute the script
+    const child = spawn('npm', ['run', 'populate:comic-covers'], {
+      detached: true,
+      stdio: 'ignore',
+      env: { ...process.env },
+      cwd: process.cwd()
+    });
+    
+    child.unref(); // Allow parent process to exit independently
+
+    // Return success response immediately
+    return response.status(200).json({
+      success: true,
+      message: 'ComicVine cover population started successfully',
+      timestamp: new Date().toISOString()
+    });
+
+  } catch (error) {
+    console.error('❌ API endpoint error:', error);
+    
+    return response.status(500).json({
+      error: 'Internal Server Error',
+      message: error instanceof Error ? error.message : 'Unknown error occurred'
+    });
+  }
+}

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "gen:types": "supabase gen types typescript --linked > src/lib/database.types.ts",
     "db:seed": "tsx scripts/import-comics-data.ts",
     "populate:market-values": "tsx scripts/populate-market-values.ts",
-    "populate:ebay-prices": "tsx scripts/populate-ebay-prices.ts"
+    "populate:ebay-prices": "tsx scripts/populate-ebay-prices.ts",
+    "populate:comic-covers": "tsx scripts/populate-comic-covers.ts"
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.56.1",


### PR DESCRIPTION
Creates admin endpoint to run ComicVine cover population

- Create /api/admin/populate-comic-covers.ts endpoint
- Requires ADMIN_SECRET authentication via POST requests
- Follows same pattern as eBay price endpoint
- Spawns populate-comic-covers script as detached process
- Add populate:comic-covers npm script

Closes #357

Generated with [Claude Code](https://claude.ai/code)