### PR TITLE
Replace Logo.svg with trace.svg and update styling

### DIFF
--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -48,9 +48,10 @@ const Footer: React.FC = () => {
           <div className="lg:col-span-2">
             <div className="flex items-center mb-4">
               <img 
-                src="/Logo.svg" 
-                alt="ComicScout UK" 
+                src="/trace.svg" 
+                alt="ComicScout UK Logo" 
                 className="h-[30px] w-auto mr-4"
+                style={{ filter: 'drop-shadow(0 0 2px rgba(255, 255, 255, 0.5))' }}
               />
               <h3 className="font-super-squad text-3xl text-golden-age-yellow">
                 COMICSCOUT UK

--- a/src/components/layout/MainNavbar.tsx
+++ b/src/components/layout/MainNavbar.tsx
@@ -113,15 +113,16 @@ const MainNavbar: React.FC<MainNavbarProps> = ({
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="flex justify-between items-center h-16">
           {/* Logo and Brand */}
-          <div className="flex items-center">
+          <div className="flex items-center justify-center">
             <button
               onClick={() => handleNavClick('/')}
-              className="flex items-center space-x-2"
+              className="flex items-center justify-center"
             >
               <img 
-                src="/Logo.svg" 
-                alt="ComicScout UK" 
-                className="h-[40px] w-auto hover:scale-105 transition-transform duration-200"
+                src="/trace.svg" 
+                alt="ComicScout UK Logo" 
+                className="h-[50px] w-auto hover:scale-105 transition-transform duration-200"
+                style={{ filter: 'drop-shadow(0 0 2px rgba(255, 255, 255, 0.8))' }}
               />
             </button>
           </div>

--- a/src/pages/AuthPage.tsx
+++ b/src/pages/AuthPage.tsx
@@ -202,9 +202,10 @@ const AuthPage: React.FC = () => {
         {/* Logo */}
         <div className="text-center mb-8">
           <img 
-            src="/Logo.svg" 
-            alt="ComicScout UK" 
+            src="/trace.svg" 
+            alt="ComicScout UK Logo" 
             className="h-[60px] w-auto mx-auto mb-4"
+            style={{ filter: 'drop-shadow(0 0 4px rgba(255, 255, 255, 0.8))' }}
           />
           <h1 className="font-super-squad text-5xl text-parchment mb-2">
             {selectedEffect}


### PR DESCRIPTION
Replace all logo references from Logo.svg to trace.svg

- Update header logo height to 50px
- Add drop-shadow filter for better visibility on dark backgrounds
- Update alt text to "ComicScout UK Logo"
- Center logo vertically in header
- Logo remains clickable and links to home

Fixes #364

Generated with [Claude Code](https://claude.ai/code)